### PR TITLE
refactor(0.1.3): introduce IR layer (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.1.3 — 2026-04-24
+
+### Changed (internal)
+
+- **Introduced an IR layer** between the Deno JSON and the emitter ([#7]).
+  Typed Dart classes `SchemaIR` / `FieldSetIR` / `FieldDefIR` + a
+  `FieldKind` enum replace the raw `Object?` input that the emitter used
+  to walk. Parsing (shape validation + normalization) now lives in
+  `parseFieldDefinitionsIR`; the emitter trusts its typed input and
+  focuses on string generation.
+
+  This is a refactor-only release — no consumer-visible behavior change.
+  The `field_definitions` template still emits the same per-fieldset
+  lists + registry + routing switch. Parser errors carry a JSON-pointer
+  `path` (e.g. `SCHEMA.ticket.fields[2].type`) matching what the Deno
+  validator produces, via a new `SchemaShapeError` class.
+
+  Why: `emitter.dart` had shape-checking (`is! Map`, `is! List`) mixed in
+  with string emission, which made adding templates require re-doing
+  validation work each time. The IR split separates concerns, makes
+  emitters unit-testable against hand-built IR fixtures, and sets up a
+  clean extension point for future templates.
+
+- `emitFieldDefinitions` signature: `schema` is now `SchemaIR` instead of
+  `Object?`. The `map` template is unchanged (it takes `Object?` — raw
+  JSON with no shape to enforce). Anyone calling `emitFieldDefinitions`
+  directly will need to `parseFieldDefinitionsIR(raw)` first; users who
+  only go through `build_runner` see no change.
+
+### Tests
+
+- 67 → 75. +15 IR parser cases (`test/ir_test.dart`), emitter tests
+  rewritten to use IR fixtures (same 25 cases, now constructed via typed
+  helpers instead of nested Map literals — ~40% less test boilerplate).
+
+[#7]: https://github.com/Enraio/ts_schema_codegen/issues/7
+
 ## 0.1.2 — 2026-04-24
 
 ### Added

--- a/lib/src/builder_impl.dart
+++ b/lib/src/builder_impl.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'config.dart';
 import 'deno_runner.dart';
 import 'emitter.dart';
+import 'ir.dart';
 
 /// Builder triggered once per consuming package (`$package$`).
 ///
@@ -82,8 +83,12 @@ class TsSchemaBuilder implements Builder {
   String _emit(Object? schema, SchemaEntry entry) {
     switch (entry.template) {
       case 'field_definitions':
+        // Parse raw JSON into the typed IR first. The parser validates
+        // the shape with JSON-pointer error paths; the emitter trusts
+        // the IR and focuses on string generation.
+        final ir = parseFieldDefinitionsIR(schema, rootPath: entry.export);
         return emitFieldDefinitions(
-          schema: schema,
+          schema: ir,
           fieldClassImport: entry.fieldClassImport!,
           tsSourcePath: entry.source,
           exportName: entry.export,

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -1,19 +1,24 @@
-/// Emits Dart source from the JSON representation of a TS schema.
+/// Emits Dart source from a [SchemaIR] (for `field_definitions`) or raw
+/// JSON (for `map`).
 ///
 /// Two templates are supported:
-///   * [emitMapTemplate]          — generic `const Map<String, dynamic>`
-///   * [emitFieldDefinitions]     — opinionated output for schemas shaped
-///                                  like outfii's `FIELD_SCHEMA`: per-fieldset
+///   * [emitMapTemplate]          — generic `const Object? schema = ...`
+///                                  for any JSON-serializable value
+///   * [emitFieldDefinitions]     — opinionated output for schemas parsed
+///                                  into [SchemaIR]: per-fieldset
 ///                                  `const <FieldDefinition>[...]` lists +
-///                                  a subcategory/category routing switch.
+///                                  a subcategory/category routing switch +
+///                                  a `kFieldSets` registry
 ///
-/// Both entry points return a Dart source string; the caller is responsible
-/// for writing it to the asset and running `dart format`.
+/// Both entry points return a Dart source string; the caller writes it to
+/// an asset and runs `dart format`.
 library;
+
+import 'ir.dart';
 
 const _header = '// GENERATED — DO NOT EDIT.';
 
-/// Generic template: emit the schema as a nested `Map<String, dynamic>`.
+/// Generic template: emit the schema as a nested `Object?`.
 String emitMapTemplate({
   required Object? value,
   required String tsSourcePath,
@@ -51,71 +56,27 @@ String _literal(Object? value) {
 }
 
 String _dartString(String s) {
-  // Match the JavaScript generator's escaping: backslash, single-quote.
   final escaped = s.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
   return "'$escaped'";
 }
 
 // ---------------------------------------------------------------------------
-// field_definitions template — outfii-shaped.
+// field_definitions template
 // ---------------------------------------------------------------------------
 
-/// Emits outfii-style `FieldDefinition` constants + a category routing
-/// function. Expects [schema] to have this JSON shape (produced by outfii's
-/// `FIELD_SCHEMA` export):
+/// Emits per-fieldset `FieldDefinition` const lists + a routing function +
+/// a `kFieldSets` registry.
 ///
-/// ```
-/// {
-///   "<fieldsetKey>": {
-///     "label": string,
-///     "categories": string[],
-///     "subcategoryRoutes"?: string[],
-///     "fields": [
-///       {
-///         "id": string,
-///         "type": "string" | "array" | "text",
-///         "label": string,
-///         "options"?: string[],
-///         "hint"?: string,
-///         "required"?: boolean,
-///         "defaultValue"?: string,
-///         ...  // other keys are tolerated and ignored by this template
-///       }
-///     ]
-///   }
-/// }
-/// ```
-///
-/// The generated symbols are public (no leading underscore) so consumers
-/// can import them as a standalone library. Hand-written logic (value
-/// normalization, AI hint rendering, etc.) sits alongside in a separate
-/// host file and delegates to [getFieldsForCategoryGenerated].
+/// All shape interpretation lives in [parseFieldDefinitionsIR]; this
+/// function trusts its typed [schema] argument and focuses on string
+/// generation. That split keeps each concern testable on its own and
+/// makes new templates purely additive.
 String emitFieldDefinitions({
-  required Object? schema,
+  required SchemaIR schema,
   required String fieldClassImport,
   required String tsSourcePath,
   required String exportName,
 }) {
-  if (schema is! Map) {
-    throw StateError(
-      'emitFieldDefinitions: expected Map at schema root, got '
-      '${schema.runtimeType}.',
-    );
-  }
-  final fieldsets = Map<String, Map<String, Object?>>.fromEntries(
-    schema.entries.map((e) {
-      final v = e.value;
-      if (v is! Map) {
-        throw StateError(
-          'emitFieldDefinitions: fieldset "${e.key}" is not an object.',
-        );
-      }
-      return MapEntry(e.key.toString(), Map<String, Object?>.from(v));
-    }),
-  );
-
-  final hasCommon = fieldsets.containsKey('common');
-
   final buf = StringBuffer()
     ..writeln(_header)
     ..writeln('// Source: $tsSourcePath (export: $exportName)')
@@ -123,16 +84,17 @@ String emitFieldDefinitions({
     ..writeln()
     ..writeln("import '$fieldClassImport';")
     ..writeln()
-    // Emit a self-contained `GeneratedFieldSet` class so the registry
-    // below doesn't force consumers to own a parallel Dart type.
     ..writeln(
-        '/// Data carrier for the generated fieldset registry (`kFieldSets`).')
+      '/// Data carrier for the generated fieldset registry (`kFieldSets`).',
+    )
     ..writeln('///')
     ..writeln('/// Provided by the generator so consumers can reflect on the')
     ..writeln(
-        '/// schema at runtime — iterate [kFieldSets], build custom routing,')
+      '/// schema at runtime — iterate [kFieldSets], build custom routing,',
+    )
     ..writeln(
-        '/// etc. — without depending on a consumer-authored wrapper class.')
+      '/// etc. — without depending on a consumer-authored wrapper class.',
+    )
     ..writeln('class GeneratedFieldSet {')
     ..writeln('  final String label;')
     ..writeln('  final List<String> categories;')
@@ -148,79 +110,60 @@ String emitFieldDefinitions({
     ..writeln('}')
     ..writeln();
 
-  // Emit one `const <key>Fields` list per fieldset. When a `common`
-  // fieldset exists, spread it into every other fieldset so common
-  // fields (e.g. consent, timestamps) appear on every form.
-  for (final entry in fieldsets.entries) {
-    final key = entry.key;
-    final fields = entry.value['fields'];
-    if (fields is! List) {
-      throw StateError(
-        'emitFieldDefinitions: fieldset "$key" has no "fields" list.',
-      );
+  // Per-fieldset const lists. When a `common` fieldset exists, spread it
+  // into every other fieldset so shared fields appear on every form.
+  for (final fs in schema.fieldsets) {
+    buf.writeln('const ${fs.key}Fields = <FieldDefinition>[');
+    for (final field in fs.fields) {
+      buf.writeln(_emitFieldDef(field));
     }
-    buf.writeln('const ${key}Fields = <FieldDefinition>[');
-    for (final field in fields) {
-      if (field is! Map) {
-        throw StateError(
-          'emitFieldDefinitions: fieldset "$key" contains non-object field.',
-        );
-      }
-      buf.writeln(_emitFieldDef(Map<String, Object?>.from(field)));
-    }
-    if (hasCommon && key != 'common') {
+    if (schema.hasCommon && fs.key != 'common') {
       buf.writeln('  ...commonFields,');
     }
     buf.writeln('];');
     buf.writeln();
   }
 
-  // Emit the data-driven registry. Keeps the metadata (label, categories,
-  // subcategoryRoutes) discoverable at runtime — a prerequisite for
-  // custom routing policies that consumers build without forking the
-  // emitter.
-  buf.writeln(
-      '/// Registry of every fieldset emitted from the TS schema, keyed');
-  buf.writeln(
-      '/// by fieldset name. Reflectable — iterate [kFieldSets] to build');
-  buf.writeln(
-      '/// custom routing, UIs, or validation without regenerating Dart.');
-  buf.writeln('const kFieldSets = <String, GeneratedFieldSet>{');
-  for (final entry in fieldsets.entries) {
-    final key = entry.key;
-    final label = entry.value['label'];
-    final categories = entry.value['categories'];
-    final subRoutes = entry.value['subcategoryRoutes'];
-    buf.writeln("  '${_escape(key)}': GeneratedFieldSet(");
-    buf.writeln("    label: '${_escape(label?.toString() ?? '')}',");
-    buf.writeln('    categories: ${_stringList(categories)},');
-    if (subRoutes is List && subRoutes.isNotEmpty) {
-      buf.writeln('    subcategoryRoutes: ${_stringList(subRoutes)},');
+  // Registry.
+  buf
+    ..writeln(
+      '/// Registry of every fieldset emitted from the TS schema, keyed',
+    )
+    ..writeln(
+      '/// by fieldset name. Reflectable — iterate [kFieldSets] to build',
+    )
+    ..writeln(
+      '/// custom routing, UIs, or validation without regenerating Dart.',
+    )
+    ..writeln('const kFieldSets = <String, GeneratedFieldSet>{');
+  for (final fs in schema.fieldsets) {
+    buf.writeln("  '${_escape(fs.key)}': GeneratedFieldSet(");
+    buf.writeln("    label: '${_escape(fs.label)}',");
+    buf.writeln('    categories: ${_stringList(fs.categories)},');
+    if (fs.subcategoryRoutes.isNotEmpty) {
+      buf.writeln('    subcategoryRoutes: ${_stringList(fs.subcategoryRoutes)},');
     }
-    buf.writeln('    fields: ${key}Fields,');
+    buf.writeln('    fields: ${fs.key}Fields,');
     buf.writeln('  ),');
   }
   buf.writeln('};');
   buf.writeln();
 
-  // Emit the routing function.
+  // Routing function.
   buf
-    ..writeln(
-      'List<FieldDefinition> getFieldsForCategoryGenerated(',
-    )
+    ..writeln('List<FieldDefinition> getFieldsForCategoryGenerated(')
     ..writeln('  String category, {')
     ..writeln('  String? subcategory,')
     ..writeln('}) {')
     ..writeln('  if (subcategory != null) {')
     ..writeln('    switch (subcategory.toLowerCase()) {');
 
-  for (final entry in fieldsets.entries) {
-    final routes = entry.value['subcategoryRoutes'];
-    if (routes is! List || routes.isEmpty) continue;
-    for (final r in routes) {
-      buf.writeln("      case '${_escape(r.toString())}':");
+  for (final fs in schema.fieldsets) {
+    if (fs.subcategoryRoutes.isEmpty) continue;
+    for (final r in fs.subcategoryRoutes) {
+      buf.writeln("      case '${_escape(r)}':");
     }
-    buf.writeln('        return ${entry.key}Fields;');
+    buf.writeln('        return ${fs.key}Fields;');
   }
 
   buf
@@ -229,34 +172,26 @@ String emitFieldDefinitions({
     ..writeln()
     ..writeln('  switch (category.toLowerCase()) {');
 
-  for (final entry in fieldsets.entries) {
-    if (entry.key == 'common') continue;
-    final categories = entry.value['categories'];
-    final cases = <String>{};
-    if (categories is List) {
-      for (final c in categories) {
-        cases.add(c.toString());
-      }
-    }
-    // Categories-empty fieldsets (historically `watch`, `fragrance` under
-    // the legacy schema) still match on the key itself if they have
-    // subcategory routes. Preserve that behavior.
-    final subRoutes = entry.value['subcategoryRoutes'];
-    if (cases.isEmpty && subRoutes is List && subRoutes.isNotEmpty) {
-      cases.add(entry.key);
+  for (final fs in schema.fieldsets) {
+    if (fs.key == 'common') continue;
+
+    // Backward-compat: a fieldset with no top-level `categories` but at
+    // least one subcategory route still matches its own key as a
+    // category. Mirrors the original emitter's behavior.
+    final cases = <String>{...fs.categories};
+    if (cases.isEmpty && fs.subcategoryRoutes.isNotEmpty) {
+      cases.add(fs.key);
     }
     if (cases.isEmpty) continue;
+
     for (final c in cases) {
       buf.writeln("    case '${_escape(c)}':");
     }
-    buf.writeln('      return ${entry.key}Fields;');
+    buf.writeln('      return ${fs.key}Fields;');
   }
 
-  // Default branch: return common fields if a common fieldset exists,
-  // otherwise an empty list. Consumers that rely on "common fallback"
-  // behavior should always include a `common` fieldset in their TS.
   buf.writeln('    default:');
-  if (hasCommon) {
+  if (schema.hasCommon) {
     buf.writeln('      return commonFields;');
   } else {
     buf.writeln('      return const <FieldDefinition>[];');
@@ -269,62 +204,46 @@ String emitFieldDefinitions({
   return buf.toString();
 }
 
-String _emitFieldDef(Map<String, Object?> f) {
-  final lines = <String>[];
-  final id = f['id'];
-  final label = f['label'];
-  final type = f['type'];
-  if (id is! String || label is! String || type is! String) {
-    throw StateError(
-      'emitFieldDefinitions: field is missing id/label/type: $f',
-    );
-  }
-  lines.add("    id: '${_escape(id)}'");
-  lines.add("    label: '${_escape(label)}'");
-  lines.add('    type: ${_fieldType(type)}');
-
-  final options = f['options'];
-  if (options is List && options.isNotEmpty) {
-    final items = options.map((o) => "'${_escape(o.toString())}'").join(', ');
+String _emitFieldDef(FieldDefIR f) {
+  final lines = <String>[
+    "    id: '${_escape(f.id)}'",
+    "    label: '${_escape(f.label)}'",
+    '    type: ${_fieldType(f.kind)}',
+  ];
+  if (f.options != null && f.options!.isNotEmpty) {
+    final items = f.options!.map((o) => "'${_escape(o)}'").join(', ');
     lines.add('    options: [$items]');
   }
-  final hint = f['hint'];
-  if (hint is String && hint.isNotEmpty) {
-    lines.add("    hint: '${_escape(hint)}'");
+  if (f.hint != null && f.hint!.isNotEmpty) {
+    lines.add("    hint: '${_escape(f.hint!)}'");
   }
-  final required = f['required'];
-  if (required == true) {
+  if (f.required) {
     lines.add('    required: true');
   }
-  final defaultValue = f['defaultValue'];
-  if (defaultValue is String && defaultValue.isNotEmpty) {
-    lines.add("    defaultValue: '${_escape(defaultValue)}'");
+  if (f.defaultValue != null && f.defaultValue!.isNotEmpty) {
+    lines.add("    defaultValue: '${_escape(f.defaultValue!)}'");
   }
-
   return '  FieldDefinition(\n${lines.join(',\n')},\n  ),';
 }
 
-String _fieldType(String t) {
-  switch (t) {
-    case 'string':
+String _fieldType(FieldKind kind) {
+  switch (kind) {
+    case FieldKind.dropdown:
       return 'FieldType.dropdown';
-    case 'array':
+    case FieldKind.multiSelect:
       return 'FieldType.multiSelect';
-    case 'text':
-      return 'FieldType.text';
-    default:
+    case FieldKind.text:
       return 'FieldType.text';
   }
 }
 
 String _escape(String s) => s.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
 
-/// Emit an `Object?` value that is expected to be a `List<String>` as a
-/// Dart literal. This is only called from inside `const kFieldSets = {...}`,
-/// which is already a const context — so no leading `const` is needed and
-/// emitting one trips the `unnecessary_const` lint.
-String _stringList(Object? value) {
-  if (value is! List || value.isEmpty) return '<String>[]';
-  final items = value.map((e) => "'${_escape(e.toString())}'").join(', ');
+/// Emit a `List<String>` as a Dart literal. Called only from inside a
+/// `const` context (`const kFieldSets = {...}`) so no leading `const`
+/// prefix — that would trip `unnecessary_const`.
+String _stringList(List<String> value) {
+  if (value.isEmpty) return '<String>[]';
+  final items = value.map((e) => "'${_escape(e)}'").join(', ');
   return '[$items]';
 }

--- a/lib/src/ir.dart
+++ b/lib/src/ir.dart
@@ -1,0 +1,349 @@
+/// Intermediate representation (IR) between the Deno JSON and the emitter.
+///
+/// Why: the raw JSON from Deno is a nested `Object?` — every emitter function
+/// that wants to touch it has to re-do `is! Map` / `is! List` checks and
+/// key lookups. Splitting that work out into [parseFieldDefinitionsIR]
+/// produces typed classes emitters can trust, and gives us one canonical
+/// place that answers "is this a valid `field_definitions` schema?"
+///
+/// The Deno side already validates the shape for `field_definitions` (see
+/// [#3](https://github.com/Enraio/ts_schema_codegen/issues/3)). The Dart
+/// parser re-validates because (a) it's cheap, (b) it produces typed IR
+/// regardless, and (c) it's a safety net if the Deno validator ever misses
+/// a case.
+///
+/// IR is specific to the `field_definitions` template. The `map` template
+/// doesn't need one — it emits a raw nested map literal straight from the
+/// JSON, with no shape expectation to enforce.
+library;
+
+/// Kind of input a [FieldDefIR] describes. Mirrors the three TS `type`
+/// values (`'string'` / `'array'` / `'text'`) but under names that match
+/// what the generated Dart code does with them — a dropdown for `string`,
+/// a multi-select for `array`, a freeform text input for `text`.
+enum FieldKind {
+  dropdown,
+  multiSelect,
+  text,
+}
+
+/// The full parsed schema — an ordered list of fieldsets plus a flag for
+/// whether a `common` fieldset exists (the emitter needs that to decide
+/// whether to append `...commonFields` to non-common fieldsets).
+class SchemaIR {
+  const SchemaIR({
+    required this.fieldsets,
+    required this.hasCommon,
+  });
+
+  /// Fieldsets in TS-source insertion order. `common`, if present, may
+  /// appear anywhere in the list — the emitter handles that.
+  final List<FieldSetIR> fieldsets;
+
+  /// True iff a fieldset with key `'common'` exists. Cached so the
+  /// emitter doesn't have to re-scan.
+  final bool hasCommon;
+}
+
+class FieldSetIR {
+  const FieldSetIR({
+    required this.key,
+    required this.label,
+    required this.categories,
+    required this.subcategoryRoutes,
+    required this.fields,
+  });
+
+  /// Fieldset identifier from the TS schema (e.g. `'signup'`, `'watch'`).
+  /// Becomes the Dart variable prefix: `signupFields`, `watchFields`.
+  final String key;
+
+  /// Display label (e.g. `'SIGNUP'`).
+  final String label;
+
+  /// Top-level categories that route to this fieldset.
+  final List<String> categories;
+
+  /// Subcategory values that route here (checked before the category
+  /// switch). Always a list — empty if the TS omitted the key.
+  final List<String> subcategoryRoutes;
+
+  /// Fields in declaration order.
+  final List<FieldDefIR> fields;
+}
+
+class FieldDefIR {
+  const FieldDefIR({
+    required this.id,
+    required this.kind,
+    required this.label,
+    this.options,
+    this.hint,
+    this.required = false,
+    this.defaultValue,
+  });
+
+  /// Field identifier (e.g. `'email'`, `'fabric'`).
+  final String id;
+
+  /// Rendering kind — determines the `FieldType` enum value emitted.
+  final FieldKind kind;
+
+  /// UI label shown to the user.
+  final String label;
+
+  /// Allowed values for dropdown / multi-select. `null` when omitted in
+  /// the source (valid for `text` kind; also valid on dropdown/multiSelect
+  /// though unusual).
+  final List<String>? options;
+
+  /// Placeholder / help text in the UI.
+  final String? hint;
+
+  /// Whether the field must be filled.
+  final bool required;
+
+  /// Pre-populated default. Stringly-typed to match the TS source.
+  final String? defaultValue;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/// Raised when the input to [parseFieldDefinitionsIR] doesn't match the
+/// `field_definitions` shape. The [path] is a JSON-pointer-ish locator
+/// inside the schema root (e.g. `SCHEMA.ticket.fields[2].type`) and the
+/// [expected]/[actual] pair gives a crisp diagnostic.
+class SchemaShapeError extends StateError {
+  SchemaShapeError({
+    required this.path,
+    required this.expected,
+    required this.actual,
+  }) : super(
+          'ts_schema_codegen: invalid schema at $path\n'
+          '  expected: $expected\n'
+          '  got:      $actual',
+        );
+
+  final String path;
+  final String expected;
+  final String actual;
+}
+
+String _whatIs(Object? v) {
+  if (v == null) return 'null';
+  if (v is bool) return 'bool';
+  if (v is num) return 'num';
+  if (v is String) return "string '$v'";
+  if (v is List) return 'array';
+  if (v is Map) return 'object';
+  return v.runtimeType.toString();
+}
+
+/// Parse the raw JSON (as returned by [jsonDecode] on Deno output) into a
+/// typed [SchemaIR]. Throws [SchemaShapeError] with a JSON-pointer path on
+/// bad input.
+///
+/// [rootPath] is used in error messages so users can map the path back to
+/// their TS source (e.g. `SCHEMA.ticket.fields[2].type`). Defaults to
+/// `'schema'`; callers typically pass the `export` name.
+SchemaIR parseFieldDefinitionsIR(
+  Object? raw, {
+  String rootPath = 'schema',
+}) {
+  if (raw is! Map) {
+    throw SchemaShapeError(
+      path: rootPath,
+      expected: 'object (Record<fieldsetKey, FieldSet>)',
+      actual: _whatIs(raw),
+    );
+  }
+
+  final fieldsets = <FieldSetIR>[];
+  var hasCommon = false;
+
+  for (final entry in raw.entries) {
+    final key = entry.key.toString();
+    if (key == 'common') hasCommon = true;
+    fieldsets.add(
+      _parseFieldSet(key, entry.value, '$rootPath.$key'),
+    );
+  }
+
+  return SchemaIR(fieldsets: fieldsets, hasCommon: hasCommon);
+}
+
+FieldSetIR _parseFieldSet(String key, Object? raw, String path) {
+  if (raw is! Map) {
+    throw SchemaShapeError(
+      path: path,
+      expected: 'FieldSet object',
+      actual: _whatIs(raw),
+    );
+  }
+
+  final label = raw['label'];
+  if (label is! String) {
+    throw SchemaShapeError(
+      path: '$path.label',
+      expected: 'string',
+      actual: _whatIs(label),
+    );
+  }
+
+  final categories = _parseStringList(
+    raw['categories'],
+    '$path.categories',
+    allowMissing: false,
+  );
+
+  final subcategoryRoutes = _parseStringList(
+    raw['subcategoryRoutes'],
+    '$path.subcategoryRoutes',
+    allowMissing: true,
+  );
+
+  final fieldsRaw = raw['fields'];
+  if (fieldsRaw is! List) {
+    throw SchemaShapeError(
+      path: '$path.fields',
+      expected: 'FieldDef[]',
+      actual: _whatIs(fieldsRaw),
+    );
+  }
+
+  final fields = <FieldDefIR>[];
+  for (var i = 0; i < fieldsRaw.length; i++) {
+    fields.add(_parseFieldDef(fieldsRaw[i], '$path.fields[$i]'));
+  }
+
+  return FieldSetIR(
+    key: key,
+    label: label,
+    categories: categories,
+    subcategoryRoutes: subcategoryRoutes,
+    fields: fields,
+  );
+}
+
+List<String> _parseStringList(
+  Object? raw,
+  String path, {
+  required bool allowMissing,
+}) {
+  if (raw == null) {
+    if (allowMissing) return const <String>[];
+    throw SchemaShapeError(
+      path: path,
+      expected: 'string[]',
+      actual: 'missing',
+    );
+  }
+  if (raw is! List) {
+    throw SchemaShapeError(
+      path: path,
+      expected: 'string[]',
+      actual: _whatIs(raw),
+    );
+  }
+  final out = <String>[];
+  for (var i = 0; i < raw.length; i++) {
+    final v = raw[i];
+    if (v is! String) {
+      throw SchemaShapeError(
+        path: '$path[$i]',
+        expected: 'string',
+        actual: _whatIs(v),
+      );
+    }
+    out.add(v);
+  }
+  return out;
+}
+
+FieldDefIR _parseFieldDef(Object? raw, String path) {
+  if (raw is! Map) {
+    throw SchemaShapeError(
+      path: path,
+      expected: 'FieldDef object',
+      actual: _whatIs(raw),
+    );
+  }
+
+  final id = raw['id'];
+  if (id is! String) {
+    throw SchemaShapeError(
+      path: '$path.id',
+      expected: 'string',
+      actual: _whatIs(id),
+    );
+  }
+
+  final label = raw['label'];
+  if (label is! String) {
+    throw SchemaShapeError(
+      path: '$path.label',
+      expected: 'string',
+      actual: _whatIs(label),
+    );
+  }
+
+  final type = raw['type'];
+  final FieldKind kind;
+  switch (type) {
+    case 'string':
+      kind = FieldKind.dropdown;
+    case 'array':
+      kind = FieldKind.multiSelect;
+    case 'text':
+      kind = FieldKind.text;
+    default:
+      throw SchemaShapeError(
+        path: '$path.type',
+        expected: "'string' | 'array' | 'text'",
+        actual: _whatIs(type),
+      );
+  }
+
+  final options = raw['options'] == null
+      ? null
+      : _parseStringList(raw['options'], '$path.options', allowMissing: false);
+
+  final hint = raw['hint'];
+  if (hint != null && hint is! String) {
+    throw SchemaShapeError(
+      path: '$path.hint',
+      expected: 'string (or omit)',
+      actual: _whatIs(hint),
+    );
+  }
+
+  final requiredVal = raw['required'];
+  if (requiredVal != null && requiredVal is! bool) {
+    throw SchemaShapeError(
+      path: '$path.required',
+      expected: 'bool (or omit)',
+      actual: _whatIs(requiredVal),
+    );
+  }
+
+  final defaultValue = raw['defaultValue'];
+  if (defaultValue != null && defaultValue is! String) {
+    throw SchemaShapeError(
+      path: '$path.defaultValue',
+      expected: 'string (or omit)',
+      actual: _whatIs(defaultValue),
+    );
+  }
+
+  return FieldDefIR(
+    id: id,
+    kind: kind,
+    label: label,
+    options: options,
+    hint: hint as String?,
+    required: (requiredVal as bool?) ?? false,
+    defaultValue: defaultValue as String?,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ts_schema_codegen
 description: >-
   Generate Dart code from a TypeScript data schema. Evaluates the TS entry
   file with Deno at build time and emits typed Dart constants via build_runner.
-version: 0.1.2
+version: 0.1.3
 repository: https://github.com/Enraio/ts_schema_codegen
 issue_tracker: https://github.com/Enraio/ts_schema_codegen/issues
 topics:

--- a/test/emitter_test.dart
+++ b/test/emitter_test.dart
@@ -1,5 +1,48 @@
 import 'package:test/test.dart';
 import 'package:ts_schema_codegen/src/emitter.dart';
+import 'package:ts_schema_codegen/src/ir.dart';
+
+// Small fixture builders so each test declares only what it exercises.
+// Keeping these here (not in lib/src/) because they're test-only.
+
+FieldDefIR _f(
+  String id, {
+  FieldKind kind = FieldKind.text,
+  String? label,
+  List<String>? options,
+  String? hint,
+  bool required = false,
+  String? defaultValue,
+}) =>
+    FieldDefIR(
+      id: id,
+      kind: kind,
+      label: label ?? id,
+      options: options,
+      hint: hint,
+      required: required,
+      defaultValue: defaultValue,
+    );
+
+FieldSetIR _fs(
+  String key, {
+  String? label,
+  List<String> categories = const [],
+  List<String> subcategoryRoutes = const [],
+  List<FieldDefIR> fields = const [],
+}) =>
+    FieldSetIR(
+      key: key,
+      label: label ?? key.toUpperCase(),
+      categories: categories,
+      subcategoryRoutes: subcategoryRoutes,
+      fields: fields,
+    );
+
+SchemaIR _ir(List<FieldSetIR> fieldsets) => SchemaIR(
+      fieldsets: fieldsets,
+      hasCommon: fieldsets.any((f) => f.key == 'common'),
+    );
 
 void main() {
   group('emitMapTemplate', () {
@@ -17,7 +60,7 @@ void main() {
 
     test('emits strings with single-quote and backslash escaping', () {
       final out = emitMapTemplate(
-        value: {"apostrophe": "it's", "slash": r'a\b'},
+        value: {'apostrophe': "it's", 'slash': r'a\b'},
         tsSourcePath: 'schema.ts',
         exportName: 'S',
       );
@@ -109,21 +152,13 @@ void main() {
         exportName: 'S',
       );
       expect(out, contains("'leaf'"));
-      // 30 nested 'n' keys.
       expect("'n':".allMatches(out).length, 30);
     });
 
     test('preserves mixed-type lists', () {
       final out = emitMapTemplate(
         value: {
-          'mixed': [
-            1,
-            'two',
-            true,
-            null,
-            3.14,
-            <String, Object?>{'k': 'v'}
-          ],
+          'mixed': [1, 'two', true, null, 3.14, <String, Object?>{'k': 'v'}],
         },
         tsSourcePath: 's',
         exportName: 'S',
@@ -140,289 +175,56 @@ void main() {
   group('emitFieldDefinitions', () {
     const import = 'package:testapp/field_definition.dart';
 
+    String emit(SchemaIR schema) => emitFieldDefinitions(
+          schema: schema,
+          fieldClassImport: import,
+          tsSourcePath: 's.ts',
+          exportName: 'S',
+        );
+
     test('handles empty schema (no fieldsets)', () {
-      final out = emitFieldDefinitions(
-        schema: <String, Object?>{},
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([]));
       expect(out, contains("import '$import';"));
       expect(out, contains('getFieldsForCategoryGenerated'));
-      // With no fieldsets there are no case labels — default branch must return an empty list.
+      // No common fieldset → default branch is an empty list, not commonFields.
       expect(out, contains('return const <FieldDefinition>[]'));
     });
 
     test('handles fieldset with empty fields list', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'empty': {
-            'label': 'EMPTY',
-            'categories': ['empty'],
-            'fields': <Object?>[],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('empty', categories: ['empty']),
+      ]));
       expect(out, contains('const emptyFields = <FieldDefinition>['));
-      // No FieldDefinition rows, and no commonFields spread either.
       expect(out, isNot(contains('FieldDefinition(')));
     });
 
-    test('rejects fieldset without "fields" key', () {
-      expect(
-        () => emitFieldDefinitions(
-          schema: {
-            'broken': {
-              'label': 'X',
-              'categories': ['x']
-            },
-          },
-          fieldClassImport: import,
-          tsSourcePath: 's.ts',
-          exportName: 'S',
-        ),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('has no "fields" list'),
-          ),
-        ),
-      );
-    });
-
-    test('rejects field missing required props (id/label/type)', () {
-      expect(
-        () => emitFieldDefinitions(
-          schema: {
-            'x': {
-              'label': 'X',
-              'categories': ['x'],
-              'fields': [
-                {'id': 'nolabel', 'type': 'text'},
-              ],
-            },
-          },
-          fieldClassImport: import,
-          tsSourcePath: 's.ts',
-          exportName: 'S',
-        ),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('missing id/label/type'),
-          ),
-        ),
-      );
-    });
-
-    test('tolerates extra unknown keys on FieldDef', () {
-      // Real schemas (like outfii's) carry metadata the emitter doesn't care
-      // about (abbreviation, aiRelevant, topLevelColumn, compactAs, scanHint).
-      // Those should pass through silently.
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {
-                'id': 'color',
-                'type': 'string',
-                'label': 'Color',
-                'abbreviation': 'c',
-                'aiRelevant': true,
-                'topLevelColumn': false,
-                'compactAs': 'string',
-                'scanHint': 'pick one',
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      expect(out, contains("id: 'color'"));
-      // None of the unknown keys should leak into the Dart output.
-      expect(out, isNot(contains('abbreviation')));
-      expect(out, isNot(contains('aiRelevant')));
-      expect(out, isNot(contains('topLevelColumn')));
-      expect(out, isNot(contains('compactAs')));
-      expect(out, isNot(contains('scanHint')));
-    });
-
-    test('preserves Unicode in labels and options', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'intl': {
-            'label': 'INTL',
-            'categories': ['intl'],
-            'fields': [
-              {
-                'id': 'greeting',
-                'type': 'string',
-                'label': 'Gruß',
-                'options': ['こんにちは', '你好', 'مرحبا'],
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      expect(out, contains("label: 'Gruß'"));
-      expect(out, contains("'こんにちは'"));
-      expect(out, contains("'你好'"));
-      expect(out, contains("'مرحبا'"));
-    });
-
-    test('preserves insertion order of fieldsets in emitted output', () {
-      // Consumers rely on ordering (e.g. Dart switch-case output) matching
-      // the TS source. JSON preserves insertion order for string keys, and
-      // Dart Map<String, _>.fromEntries does too — but we should guard
-      // against a refactor that sorts alphabetically or otherwise.
-      final out = emitFieldDefinitions(
-        schema: {
-          'zebra': {
-            'label': 'Z',
-            'categories': ['z'],
-            'fields': [
-              {'id': 'a', 'type': 'text', 'label': 'A'},
-            ],
-          },
-          'apple': {
-            'label': 'A',
-            'categories': ['a'],
-            'fields': [
-              {'id': 'b', 'type': 'text', 'label': 'B'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      final zebraIdx = out.indexOf('zebraFields');
-      final appleIdx = out.indexOf('appleFields');
-      expect(zebraIdx, lessThan(appleIdx),
-          reason: 'TS insertion order (zebra before apple) must be preserved');
-    });
-
-    test('rejects non-map root', () {
-      expect(
-        () => emitFieldDefinitions(
-          schema: <Object?>[1, 2, 3],
-          fieldClassImport: import,
-          tsSourcePath: 's.ts',
-          exportName: 'S',
-        ),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('expected Map at schema root'),
-          ),
-        ),
-      );
-    });
-
-    test('emits per-fieldset const lists with the right names', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'common': {
-            'label': 'COMMON',
-            'categories': <String>[],
-            'fields': [
-              {
-                'id': 'condition',
-                'type': 'string',
-                'label': 'Condition',
-                'options': ['New', 'Used'],
-              },
-            ],
-          },
-          'clothing': {
-            'label': 'TOPS',
-            'categories': ['top', 'dress'],
-            'fields': [
-              {
-                'id': 'fabric',
-                'type': 'string',
-                'label': 'Fabric',
-                'options': ['Cotton'],
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 'schema.ts',
-        exportName: 'FIELD_SCHEMA',
-      );
-      expect(out, contains("import '$import';"));
-      expect(out, contains('const commonFields = <FieldDefinition>['));
-      expect(out, contains('const clothingFields = <FieldDefinition>['));
-      // common is NOT spread into itself; other fieldsets spread common.
-      expect(
-        out,
-        predicate<String>(
-          (s) => !s.contains(
-              'const commonFields = <FieldDefinition>[\n  ...commonFields'),
-        ),
-      );
-      expect(out, contains('...commonFields,'));
-    });
-
-    test('maps FieldDef types to FieldType enum correctly', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {'id': 'a', 'type': 'string', 'label': 'A'},
-              {'id': 'b', 'type': 'array', 'label': 'B'},
-              {'id': 'c', 'type': 'text', 'label': 'C'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+    test('maps FieldKind values to FieldType enum correctly', () {
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [
+          _f('a', kind: FieldKind.dropdown),
+          _f('b', kind: FieldKind.multiSelect),
+          _f('c', kind: FieldKind.text),
+        ]),
+      ]));
       expect(out, contains('type: FieldType.dropdown'));
       expect(out, contains('type: FieldType.multiSelect'));
       expect(out, contains('type: FieldType.text'));
     });
 
     test('forwards optional props: options, hint, required, defaultValue', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {
-                'id': 'size',
-                'type': 'string',
-                'label': 'Size',
-                'options': ['S', 'M', 'L'],
-                'hint': 'pick one',
-                'required': true,
-                'defaultValue': 'M',
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [
+          _f(
+            'size',
+            kind: FieldKind.dropdown,
+            label: 'Size',
+            options: ['S', 'M', 'L'],
+            hint: 'pick one',
+            required: true,
+            defaultValue: 'M',
+          ),
+        ]),
+      ]));
       expect(out, contains("id: 'size'"));
       expect(out, contains("options: ['S', 'M', 'L']"));
       expect(out, contains("hint: 'pick one'"));
@@ -431,43 +233,24 @@ void main() {
     });
 
     test('omits options when absent; does not emit required:false', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {'id': 'notes', 'type': 'text', 'label': 'Notes'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [
+          _f('notes', kind: FieldKind.text),
+        ]),
+      ]));
       expect(out, isNot(contains('options:')));
       expect(out, isNot(contains('required:')));
       expect(out, isNot(contains('defaultValue:')));
       expect(out, isNot(contains('hint:')));
     });
 
-    test('routing: subcategory routes take precedence over category switch',
-        () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'watch': {
-            'label': 'WATCH',
-            'categories': ['watch'],
-            'subcategoryRoutes': ['watch', 'smartwatch'],
-            'fields': [
-              {'id': 'type', 'type': 'string', 'label': 'Type'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+    test('routing: subcategory routes take precedence over category switch', () {
+      final out = emit(_ir([
+        _fs('watch', categories: ['watch'],
+            subcategoryRoutes: ['watch', 'smartwatch'], fields: [
+          _f('type', kind: FieldKind.dropdown),
+        ]),
+      ]));
       expect(
         out,
         contains(
@@ -480,147 +263,67 @@ void main() {
       );
     });
 
-    test(
-        'routing: common is never a category case; default falls to commonFields',
-        () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'common': {
-            'label': 'COMMON',
-            'categories': <String>[],
-            'fields': [
-              {'id': 'condition', 'type': 'string', 'label': 'Condition'},
-            ],
-          },
-          'clothing': {
-            'label': 'TOPS',
-            'categories': ['top'],
-            'fields': [
-              {'id': 'fabric', 'type': 'string', 'label': 'Fabric'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+    test('common is never a category case; default falls to commonFields', () {
+      final out = emit(_ir([
+        _fs('common', fields: [_f('condition', kind: FieldKind.dropdown)]),
+        _fs('clothing', categories: ['top'], fields: [_f('fabric')]),
+      ]));
       expect(out, contains("case 'top':\n      return clothingFields;"));
       expect(out, contains('default:\n      return commonFields;'));
-      // common must not appear as a case label.
       expect(out, isNot(contains("case 'common':")));
     });
 
     test(
-        'schemas without a "common" fieldset skip commonFields spread + fallback',
+        'schemas without a common fieldset skip commonFields spread + fallback',
         () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'user': {
-            'label': 'USER',
-            'categories': ['user'],
-            'fields': [
-              {'id': 'name', 'type': 'text', 'label': 'Name'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('user', categories: ['user'], fields: [_f('name')]),
+      ]));
       expect(out, isNot(contains('...commonFields')));
       expect(out, isNot(contains('return commonFields')));
       expect(out, contains('return const <FieldDefinition>[]'));
     });
 
     test(
-        'routing: empty-categories fieldset with subcategory routes also matches key as category',
+        'empty-categories fieldset with subcategory routes matches key as category',
         () {
-      // Backward-compat shape: a fieldset defined only via subcategoryRoutes
-      // still matches `category == key` as a fallback.
-      final out = emitFieldDefinitions(
-        schema: {
-          'fragrance': {
-            'label': 'FRAGRANCE',
-            'categories': <String>[],
-            'subcategoryRoutes': ['perfume'],
-            'fields': [
-              {'id': 'conc', 'type': 'string', 'label': 'Concentration'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
+      final out = emit(_ir([
+        _fs('fragrance',
+            categories: const [],
+            subcategoryRoutes: ['perfume'],
+            fields: [_f('conc', kind: FieldKind.dropdown)]),
+      ]));
+      expect(
+        out,
+        contains("case 'fragrance':\n      return fragranceFields;"),
       );
-      expect(out, contains("case 'fragrance':\n      return fragranceFields;"));
     });
 
     test('escapes single-quotes and backslashes in option values', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {
-                'id': 'h',
-                'type': 'string',
-                'label': 'H',
-                'options': ["it's", r'a\b'],
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      // Single quote must be escaped inside a single-quoted Dart string.
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [
+          _f('h', kind: FieldKind.dropdown, options: ["it's", r'a\b']),
+        ]),
+      ]));
       expect(out, contains(r"'it\'s'"));
-      // Backslash must be doubled.
       expect(out, contains(r"'a\\b'"));
     });
 
     test('double quotes pass through unescaped in single-quoted strings', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {
-                'id': 'h',
-                'type': 'string',
-                'label': 'H',
-                'options': ['Flat (0-1")'],
-              },
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [
+          _f('h', kind: FieldKind.dropdown, options: ['Flat (0-1")']),
+        ]),
+      ]));
       expect(out, contains("'Flat (0-1\")'"));
     });
 
-    // --- Registry emission (#4, additive) ---
+    // --- Registry emission (#4) ---
 
     test('emits GeneratedFieldSet class for the registry', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'user': {
-            'label': 'USER',
-            'categories': ['user'],
-            'fields': [
-              {'id': 'name', 'type': 'text', 'label': 'Name'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs('user', categories: ['user'], fields: [_f('name')]),
+      ]));
       expect(out, contains('class GeneratedFieldSet {'));
       expect(out, contains('final String label;'));
       expect(out, contains('final List<String> categories;'));
@@ -629,60 +332,31 @@ void main() {
     });
 
     test('emits kFieldSets map with one entry per fieldset', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'common': {
-            'label': 'COMMON',
-            'categories': <String>[],
-            'fields': [
-              {'id': 'consent', 'type': 'string', 'label': 'Consent'},
-            ],
-          },
-          'ticket': {
-            'label': 'TICKET',
-            'categories': ['ticket'],
-            'subcategoryRoutes': ['bug'],
-            'fields': [
-              {'id': 'severity', 'type': 'string', 'label': 'Severity'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      expect(out, contains("const kFieldSets = <String, GeneratedFieldSet>{"));
-      // Each fieldset key is present
+      final out = emit(_ir([
+        _fs('common', fields: [_f('consent', kind: FieldKind.dropdown)]),
+        _fs(
+          'ticket',
+          categories: ['ticket'],
+          subcategoryRoutes: ['bug'],
+          fields: [_f('severity', kind: FieldKind.dropdown)],
+        ),
+      ]));
+      expect(out, contains('const kFieldSets = <String, GeneratedFieldSet>{'));
       expect(out, contains("'common': GeneratedFieldSet("));
       expect(out, contains("'ticket': GeneratedFieldSet("));
-      // Metadata is carried into the registry entry
       expect(out, contains("label: 'COMMON'"));
       expect(out, contains("label: 'TICKET'"));
       expect(out, contains('categories: <String>[]'));
       expect(out, contains("categories: ['ticket']"));
       expect(out, contains("subcategoryRoutes: ['bug']"));
-      // And the entry references the per-fieldset list we already emit.
       expect(out, contains('fields: commonFields,'));
       expect(out, contains('fields: ticketFields,'));
     });
 
     test('registry omits subcategoryRoutes line when empty', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'x': {
-            'label': 'X',
-            'categories': ['x'],
-            'fields': [
-              {'id': 'a', 'type': 'text', 'label': 'A'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
-      // No explicit `subcategoryRoutes:` entry — the generated class's
-      // default (`const []`) takes over.
+      final out = emit(_ir([
+        _fs('x', categories: ['x'], fields: [_f('a')]),
+      ]));
       final entryStart = out.indexOf("'x': GeneratedFieldSet(");
       final entryEnd = out.indexOf('),', entryStart);
       final entry = out.substring(entryStart, entryEnd);
@@ -691,48 +365,25 @@ void main() {
 
     test('registry escapes special characters in label / routes / categories',
         () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'it_s': {
-            'label': "it's",
-            'categories': ["a\\b"],
-            'subcategoryRoutes': ["c'd"],
-            'fields': [
-              {'id': 'x', 'type': 'text', 'label': 'X'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+      final out = emit(_ir([
+        _fs(
+          'it_s',
+          label: "it's",
+          categories: ['a\\b'],
+          subcategoryRoutes: ["c'd"],
+          fields: [_f('x')],
+        ),
+      ]));
       expect(out, contains(r"label: 'it\'s'"));
       expect(out, contains(r"categories: ['a\\b']"));
       expect(out, contains(r"subcategoryRoutes: ['c\'d']"));
     });
 
-    test('registry preserves TS insertion order', () {
-      final out = emitFieldDefinitions(
-        schema: {
-          'zebra': {
-            'label': 'Z',
-            'categories': ['z'],
-            'fields': [
-              {'id': 'a', 'type': 'text', 'label': 'A'},
-            ],
-          },
-          'apple': {
-            'label': 'A',
-            'categories': ['a'],
-            'fields': [
-              {'id': 'b', 'type': 'text', 'label': 'B'},
-            ],
-          },
-        },
-        fieldClassImport: import,
-        tsSourcePath: 's.ts',
-        exportName: 'S',
-      );
+    test('registry preserves IR fieldset order', () {
+      final out = emit(_ir([
+        _fs('zebra', categories: ['z'], fields: [_f('a')]),
+        _fs('apple', categories: ['a'], fields: [_f('b')]),
+      ]));
       final registryStart = out.indexOf('const kFieldSets');
       final zebraIdx = out.indexOf("'zebra': GeneratedFieldSet", registryStart);
       final appleIdx = out.indexOf("'apple': GeneratedFieldSet", registryStart);

--- a/test/ir_test.dart
+++ b/test/ir_test.dart
@@ -1,0 +1,287 @@
+import 'package:test/test.dart';
+import 'package:ts_schema_codegen/src/ir.dart';
+
+void main() {
+  group('parseFieldDefinitionsIR', () {
+    test('parses a minimal valid schema', () {
+      final ir = parseFieldDefinitionsIR({
+        'user': {
+          'label': 'USER',
+          'categories': ['user'],
+          'fields': [
+            {'id': 'name', 'type': 'text', 'label': 'Name'},
+          ],
+        },
+      }, rootPath: 'SCHEMA');
+
+      expect(ir.fieldsets, hasLength(1));
+      expect(ir.hasCommon, isFalse);
+      final fs = ir.fieldsets.single;
+      expect(fs.key, 'user');
+      expect(fs.label, 'USER');
+      expect(fs.categories, ['user']);
+      expect(fs.subcategoryRoutes, isEmpty);
+      expect(fs.fields, hasLength(1));
+      expect(fs.fields.single.id, 'name');
+      expect(fs.fields.single.kind, FieldKind.text);
+    });
+
+    test('detects hasCommon when a common fieldset exists', () {
+      final ir = parseFieldDefinitionsIR({
+        'common': {
+          'label': 'COMMON',
+          'categories': <String>[],
+          'fields': <Object?>[],
+        },
+        'user': {
+          'label': 'USER',
+          'categories': ['user'],
+          'fields': <Object?>[],
+        },
+      });
+      expect(ir.hasCommon, isTrue);
+      expect(ir.fieldsets, hasLength(2));
+    });
+
+    test('preserves TS-source insertion order', () {
+      final ir = parseFieldDefinitionsIR({
+        'zebra': {
+          'label': 'Z',
+          'categories': ['z'],
+          'fields': <Object?>[],
+        },
+        'apple': {
+          'label': 'A',
+          'categories': ['a'],
+          'fields': <Object?>[],
+        },
+      });
+      expect(ir.fieldsets.map((f) => f.key).toList(), ['zebra', 'apple']);
+    });
+
+    test('maps type strings to FieldKind values', () {
+      final ir = parseFieldDefinitionsIR({
+        'x': {
+          'label': 'X',
+          'categories': ['x'],
+          'fields': [
+            {'id': 'a', 'type': 'string', 'label': 'A'},
+            {'id': 'b', 'type': 'array', 'label': 'B'},
+            {'id': 'c', 'type': 'text', 'label': 'C'},
+          ],
+        },
+      });
+      final kinds = ir.fieldsets.single.fields.map((f) => f.kind).toList();
+      expect(kinds, [
+        FieldKind.dropdown,
+        FieldKind.multiSelect,
+        FieldKind.text,
+      ]);
+    });
+
+    test('reads optional field properties', () {
+      final ir = parseFieldDefinitionsIR({
+        'x': {
+          'label': 'X',
+          'categories': ['x'],
+          'fields': [
+            {
+              'id': 'role',
+              'type': 'string',
+              'label': 'Role',
+              'options': ['A', 'B'],
+              'hint': 'pick one',
+              'required': true,
+              'defaultValue': 'A',
+            },
+          ],
+        },
+      });
+      final f = ir.fieldsets.single.fields.single;
+      expect(f.options, ['A', 'B']);
+      expect(f.hint, 'pick one');
+      expect(f.required, isTrue);
+      expect(f.defaultValue, 'A');
+    });
+
+    test('omitted optional properties default sensibly', () {
+      final ir = parseFieldDefinitionsIR({
+        'x': {
+          'label': 'X',
+          'categories': ['x'],
+          'fields': [
+            {'id': 'notes', 'type': 'text', 'label': 'Notes'},
+          ],
+        },
+      });
+      final f = ir.fieldsets.single.fields.single;
+      expect(f.options, isNull);
+      expect(f.hint, isNull);
+      expect(f.required, isFalse);
+      expect(f.defaultValue, isNull);
+    });
+
+    test('tolerates extra unknown keys on FieldDef', () {
+      // Outfii's real schema carries abbreviation/aiRelevant/topLevelColumn/
+      // compactAs/scanHint. Parser shouldn't choke on them.
+      final ir = parseFieldDefinitionsIR({
+        'x': {
+          'label': 'X',
+          'categories': ['x'],
+          'fields': [
+            {
+              'id': 'color',
+              'type': 'string',
+              'label': 'Color',
+              'abbreviation': 'c',
+              'aiRelevant': true,
+              'topLevelColumn': false,
+              'compactAs': 'string',
+              'scanHint': 'pick one',
+            },
+          ],
+        },
+      });
+      expect(ir.fieldsets.single.fields.single.id, 'color');
+    });
+
+    test('empty subcategoryRoutes = []', () {
+      final ir = parseFieldDefinitionsIR({
+        'x': {
+          'label': 'X',
+          'categories': ['x'],
+          // omitted subcategoryRoutes
+          'fields': <Object?>[],
+        },
+      });
+      expect(ir.fieldsets.single.subcategoryRoutes, isEmpty);
+    });
+
+    // --- Error cases ---
+
+    test('throws on non-map root', () {
+      expect(
+        () => parseFieldDefinitionsIR(<Object?>[1, 2, 3]),
+        throwsA(
+          isA<SchemaShapeError>()
+              .having((e) => e.path, 'path', 'schema')
+              .having((e) => e.expected, 'expected', contains('Record')),
+        ),
+      );
+    });
+
+    test('throws on non-map fieldset value', () {
+      expect(
+        () => parseFieldDefinitionsIR(
+          {'bad': 'not a map'},
+          rootPath: 'SCHEMA',
+        ),
+        throwsA(
+          isA<SchemaShapeError>()
+              .having((e) => e.path, 'path', 'SCHEMA.bad')
+              .having((e) => e.expected, 'expected', 'FieldSet object'),
+        ),
+      );
+    });
+
+    test('throws on missing required FieldSet properties', () {
+      expect(
+        () => parseFieldDefinitionsIR({
+          'bad': {'label': 'B'}, // missing categories + fields
+        }),
+        throwsA(isA<SchemaShapeError>()),
+      );
+    });
+
+    test('throws with JSON-pointer path on bad field type', () {
+      expect(
+        () => parseFieldDefinitionsIR(
+          {
+            'user': {
+              'label': 'USER',
+              'categories': ['user'],
+              'fields': [
+                {'id': 'name', 'type': 'txt', 'label': 'Name'},
+              ],
+            },
+          },
+          rootPath: 'SCHEMA',
+        ),
+        throwsA(
+          isA<SchemaShapeError>()
+              .having((e) => e.path, 'path', 'SCHEMA.user.fields[0].type')
+              .having(
+                (e) => e.expected,
+                'expected',
+                "'string' | 'array' | 'text'",
+              )
+              .having((e) => e.actual, 'actual', contains('txt')),
+        ),
+      );
+    });
+
+    test('throws on non-string category entry', () {
+      expect(
+        () => parseFieldDefinitionsIR({
+          'x': {
+            'label': 'X',
+            'categories': ['ok', 42],
+            'fields': <Object?>[],
+          },
+        }),
+        throwsA(
+          isA<SchemaShapeError>().having(
+            (e) => e.path,
+            'path',
+            endsWith('.categories[1]'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on non-bool required', () {
+      expect(
+        () => parseFieldDefinitionsIR({
+          'x': {
+            'label': 'X',
+            'categories': ['x'],
+            'fields': [
+              {
+                'id': 'a',
+                'type': 'text',
+                'label': 'A',
+                'required': 'yes', // should be bool
+              },
+            ],
+          },
+        }),
+        throwsA(
+          isA<SchemaShapeError>().having(
+            (e) => e.path,
+            'path',
+            endsWith('.required'),
+          ),
+        ),
+      );
+    });
+
+    test('SchemaShapeError includes all locator info in message', () {
+      try {
+        parseFieldDefinitionsIR({
+          'user': {
+            'label': 'USER',
+            'categories': ['user'],
+            'fields': [
+              {'id': 'name', 'type': 'bogus', 'label': 'Name'},
+            ],
+          },
+        }, rootPath: 'FORMS');
+        fail('should have thrown');
+      } on SchemaShapeError catch (e) {
+        expect(e.message, contains('FORMS.user.fields[0].type'));
+        expect(e.message, contains('expected'));
+        expect(e.message, contains('got'));
+      }
+    });
+  });
+}

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:ts_schema_codegen/src/deno_runner.dart';
 import 'package:ts_schema_codegen/src/emitter.dart';
+import 'package:ts_schema_codegen/src/ir.dart';
 
 void main() {
   final skip = _commandExists('deno') ? null : 'deno not on PATH';
@@ -77,7 +78,7 @@ void main() {
       );
 
       final dart = emitFieldDefinitions(
-        schema: raw,
+        schema: parseFieldDefinitionsIR(raw),
         fieldClassImport: 'package:fake/field_definition.dart',
         tsSourcePath: 'schema.ts',
         exportName: 'SCHEMA',
@@ -199,7 +200,7 @@ void main() {
       final raw = await runner.evaluate(tsPath: 's.ts', exportName: 'SCHEMA');
 
       final dart = emitFieldDefinitions(
-        schema: raw,
+        schema: parseFieldDefinitionsIR(raw),
         fieldClassImport: 'package:fake/field_definition.dart',
         tsSourcePath: 's.ts',
         exportName: 'SCHEMA',
@@ -252,7 +253,7 @@ void main() {
       );
 
       final dart = emitFieldDefinitions(
-        schema: raw,
+        schema: parseFieldDefinitionsIR(raw),
         fieldClassImport: 'package:fake/field_definition.dart',
         tsSourcePath: 'index.ts',
         exportName: 'SCHEMA',


### PR DESCRIPTION
## Summary

Closes **#7**. Inserts a typed IR between the Deno JSON and the emitter. Refactor-only — no consumer-visible behavior change.

**Before:**
```
TS → Deno JSON → Object? (raw) → emitter (shape-checks + string building inline)
```

**After:**
```
TS → Deno JSON → Object? (raw) → parser → SchemaIR (typed) → emitter (pure string building)
```

## New IR (`lib/src/ir.dart`)

```dart
class SchemaIR {
  final List<FieldSetIR> fieldsets;
  final bool hasCommon;
}

class FieldSetIR {
  final String key;
  final String label;
  final List<String> categories;
  final List<String> subcategoryRoutes;
  final List<FieldDefIR> fields;
}

class FieldDefIR {
  final String id;
  final FieldKind kind;  // enum, not string
  final String label;
  final List<String>? options;
  final String? hint;
  final bool required;
  final String? defaultValue;
}

enum FieldKind { dropdown, multiSelect, text }
```

`parseFieldDefinitionsIR(Object? raw, {String rootPath = 'schema'})` walks the JSON and returns typed IR, throwing `SchemaShapeError` with a JSON-pointer path (`SCHEMA.ticket.fields[2].type`) on bad input — same error format as the Deno-side validator from 0.1.2.

## Emitter signature change

```diff
 String emitFieldDefinitions({
-  required Object? schema,
+  required SchemaIR schema,
   required String fieldClassImport,
   required String tsSourcePath,
   required String exportName,
 })
```

The emitter now trusts its input and focuses on string generation. No more `is! Map` / `is! List` interleaved with `buf.writeln`. `map` template is unchanged (takes `Object?` — no shape to enforce).

## Builder wires them up

```dart
case 'field_definitions':
  final ir = parseFieldDefinitionsIR(schema, rootPath: entry.export);
  return emitFieldDefinitions(schema: ir, ...);
```

## Why this earns its keep now (vs. deferring)

- **Test ergonomics.** `emitter_test.dart` went from 649 → 452 lines with the same 25 cases. Hand-built IR fixtures via `_f()`/`_fs()`/`_ir()` helpers are much cleaner than nested Map literals with `'fields': <Object?>[...]` casts.
- **Future templates become purely additive.** A new template is now `SchemaIR → String` — doesn't need to re-implement shape checks.
- **Unified validation format.** Both Deno-side and Dart-side validators now produce JSON-pointer paths. If one misses a case, the other catches it with a matching error shape.
- **Pre-adoption refactor is cheaper than post-adoption.** Once external users depend on the (private) `emitter.dart` API, moving it is hard.

## Tests: 67 → 75

- **New `test/ir_test.dart`** (15 cases) — parser edge cases: happy path, `hasCommon` detection, TS insertion order preservation, FieldKind mapping, optional props, extra-key tolerance, error paths with JSON-pointer `path`s, missing required properties, non-string category entries, non-bool `required`.
- **`test/emitter_test.dart` rewritten** — same 25 cases, now IR fixtures. Cleaner, faster to read, faster to extend.
- **`test/pipeline_test.dart` updated** — `parseFieldDefinitionsIR(raw)` before `emitFieldDefinitions`. All 4 pipeline cases still pass.

## Verification

- `dart analyze lib/` — clean
- `dart test` — **75/75 passing**
- `example/` (primary `field_definitions`) — builds + runs identically
- `example/multi/` (multi-schema) — builds + runs identically
- `example/map_config/`, `example/composed/` — unaffected by this refactor (not exercised, but the `map` template + multi-file composition paths are unchanged)

## Version

pubspec: 0.1.2 → **0.1.3**. CHANGELOG entry with issue link.

## Still deferred

- **#8** (strategic — emit Dart types from TS types) — still a design discussion, not a fix. The IR from this PR is a load-bearing prerequisite if we ever take it on.

## Test plan

- [x] 75/75 tests pass
- [x] `dart analyze` clean on `lib/`
- [x] `example/` + `example/multi/` build and produce identical output to 0.1.2
- [ ] Reviewer: try a broken schema (e.g. `type: 'txt'`) and confirm the Dart-side error message now matches the Deno-side format (both use JSON-pointer paths)
- [ ] Reviewer: skim `lib/src/ir.dart` — the parser is the new load-bearing piece