### PR TITLE
chore(0.1.4): lint cleanup — zero analyzer issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.1.4 — 2026-04-24
+
+### Changed
+
+- `map` template now emits `const Object schema = ...` (non-nullable) when
+  the evaluated TS export is non-null, and `const Object? schema = null`
+  only when the export is literally `null`. Previously always emitted
+  `const Object?`, which tripped `unnecessary_nullable_for_final_variable_declarations`
+  in consumer projects that lint generated files.
+
+### Cleanup (non-semantic)
+
+- Removed unused `field_definition.dart` imports from `example/lib/main.dart`,
+  `example/composed/lib/main.dart`, `example/multi/lib/main.dart`. The `.name`
+  accessor on `FieldType` values doesn't require the type to be in scope.
+- Converted a handful of double-quoted strings in tests to single quotes
+  (`prefer_single_quotes`).
+
+### Tests
+
+- 75 → 77. +2 emitter cases: `emits Object (non-nullable) when value is non-null`
+  and `emits Object? when value is literally null`.
+
+### Result
+
+`dart analyze` over the whole package (lib + test + all four runnable
+examples) now reports `No issues found!`.
+
 ## 0.1.3 — 2026-04-24
 
 ### Changed (internal)

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ dart run build_runner watch
 
 ### `map`
 
-Generic. Emits the export as a nested `const Object? schema = {...}`.
+Generic. Emits the export as a nested `const Object schema = {...}` (or `const Object? schema = null` when the TS export is literally null).
 
 **Input:**
 ```ts
@@ -276,7 +276,7 @@ export const CONFIG = {
 
 **Generated output:**
 ```dart
-const Object? schema = <String, Object?>{
+const Object schema = <String, Object?>{
   'version': '2.3.1',
   'api': <String, Object?>{'baseUrl': 'https://api.example.com', 'timeoutMs': 30000},
   'features': <String, Object?>{'dark_mode': true, 'beta': false},

--- a/example/composed/lib/main.dart
+++ b/example/composed/lib/main.dart
@@ -3,7 +3,6 @@
 // Run after `dart run build_runner build`:
 //   dart run lib/main.dart
 
-import 'field_definition.dart';
 import 'ts_schema.g.dart' as g;
 
 void main() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 // Smoke script. Run after `dart run build_runner build`:
 //   dart run lib/main.dart
 
-import 'field_definition.dart';
 import 'ts_schema.g.dart' as g;
 
 void main() {

--- a/example/map_config/README.md
+++ b/example/map_config/README.md
@@ -1,7 +1,7 @@
 # example/map_config — `map` template
 
 The lightest-weight template. Emits the TS export as a nested
-`const Object? schema` — just data, no opinions about structure. Use this
+`const Object schema` (non-nullable) — just data, no opinions about structure. Use this
 when your schema doesn't fit the fieldset shape, or when you want to parse
 it into your own types at runtime.
 
@@ -31,7 +31,7 @@ Feature flags:
 `lib/ts_schema.g.dart` contains:
 
 ```dart
-const Object? schema = <String, Object?>{
+const Object schema = <String, Object?>{
   'version': '2.3.1',
   'api': <String, Object?>{
     'baseUrl': 'https://api.example.com',

--- a/example/map_config/lib/main.dart
+++ b/example/map_config/lib/main.dart
@@ -5,7 +5,8 @@
 import 'ts_schema.g.dart';
 
 void main() {
-  // The `map` template emits `const Object? schema`. Cast once at the
+  // The `map` template emits `const Object schema` (or `Object?` if the
+  // TS export is literally null). Cast once at the
   // boundary; in a real app you'd wrap this in a typed config class.
   final cfg = schema as Map<String, Object?>;
 

--- a/example/map_config/schema.ts
+++ b/example/map_config/schema.ts
@@ -1,5 +1,5 @@
 // A generic application config with feature flags. The `map` template
-// emits this as a nested `const Object? schema` — nothing typed, just data.
+// emits this as a nested `const Object schema` — nothing typed, just data.
 
 export const CONFIG = {
   version: '2.3.1',

--- a/example/multi/lib/main.dart
+++ b/example/multi/lib/main.dart
@@ -4,7 +4,6 @@
 //   dart run lib/main.dart
 
 import 'config.g.dart' as cfg;
-import 'field_definition.dart';
 import 'forms.g.dart' as forms;
 
 void main() {

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -18,18 +18,25 @@ import 'ir.dart';
 
 const _header = '// GENERATED — DO NOT EDIT.';
 
-/// Generic template: emit the schema as a nested `Object?`.
+/// Generic template: emit the schema as a nested `Object`.
+///
+/// Emits `const Object schema = ...` when the value is non-null (the common
+/// case) and `const Object? schema = null` only when the evaluated export
+/// is literally `null`. Keeps the analyzer happy
+/// (`unnecessary_nullable_for_final_variable_declarations`) without hiding
+/// the null-at-root case.
 String emitMapTemplate({
   required Object? value,
   required String tsSourcePath,
   required String exportName,
 }) {
+  final type = value == null ? 'Object?' : 'Object';
   final buf = StringBuffer()
     ..writeln(_header)
     ..writeln('// Source: $tsSourcePath (export: $exportName)')
     ..writeln('// Regenerate: dart run build_runner build')
     ..writeln()
-    ..writeln('const Object? schema = ${_literal(value)};')
+    ..writeln('const $type schema = ${_literal(value)};')
     ..writeln();
   return buf.toString();
 }
@@ -141,7 +148,8 @@ String emitFieldDefinitions({
     buf.writeln("    label: '${_escape(fs.label)}',");
     buf.writeln('    categories: ${_stringList(fs.categories)},');
     if (fs.subcategoryRoutes.isNotEmpty) {
-      buf.writeln('    subcategoryRoutes: ${_stringList(fs.subcategoryRoutes)},');
+      buf.writeln(
+          '    subcategoryRoutes: ${_stringList(fs.subcategoryRoutes)},');
     }
     buf.writeln('    fields: ${fs.key}Fields,');
     buf.writeln('  ),');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ts_schema_codegen
 description: >-
   Generate Dart code from a TypeScript data schema. Evaluates the TS entry
   file with Deno at build time and emits typed Dart constants via build_runner.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/Enraio/ts_schema_codegen
 issue_tracker: https://github.com/Enraio/ts_schema_codegen/issues
 topics:

--- a/test/deno_runner_test.dart
+++ b/test/deno_runner_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     test('evaluates a primitive export', () async {
       File(p.join(tmp.path, 'schema.ts'))
-          .writeAsStringSync("export const answer = 42;\n");
+          .writeAsStringSync('export const answer = 42;\n');
       final runner = DenoRunner(
         denoCommand: 'deno',
         exportScriptPath: exportScript,
@@ -94,7 +94,7 @@ void main() {
 
     test('fails loudly when the named export is missing', () async {
       File(p.join(tmp.path, 'schema.ts'))
-          .writeAsStringSync("export const foo = 1;\n");
+          .writeAsStringSync('export const foo = 1;\n');
       final runner = DenoRunner(
         denoCommand: 'deno',
         exportScriptPath: exportScript,
@@ -114,7 +114,7 @@ void main() {
 
     test('fails loudly when export is not JSON-serializable', () async {
       File(p.join(tmp.path, 'schema.ts'))
-          .writeAsStringSync("export const fn = () => 42;\n");
+          .writeAsStringSync('export const fn = () => 42;\n');
       final runner = DenoRunner(
         denoCommand: 'deno',
         exportScriptPath: exportScript,

--- a/test/emitter_test.dart
+++ b/test/emitter_test.dart
@@ -108,6 +108,25 @@ void main() {
       expect(out, contains('dart run build_runner build'));
     });
 
+    test('emits `Object` (non-nullable) when value is non-null', () {
+      final out = emitMapTemplate(
+        value: {'a': 1},
+        tsSourcePath: 's',
+        exportName: 'S',
+      );
+      expect(out, contains('const Object schema = '));
+      expect(out, isNot(contains('const Object? schema')));
+    });
+
+    test('emits `Object?` when value is literally null', () {
+      final out = emitMapTemplate(
+        value: null,
+        tsSourcePath: 's',
+        exportName: 'S',
+      );
+      expect(out, contains('const Object? schema = null;'));
+    });
+
     test('rejects non-JSON types', () {
       expect(
         () => emitMapTemplate(
@@ -158,7 +177,14 @@ void main() {
     test('preserves mixed-type lists', () {
       final out = emitMapTemplate(
         value: {
-          'mixed': [1, 'two', true, null, 3.14, <String, Object?>{'k': 'v'}],
+          'mixed': [
+            1,
+            'two',
+            true,
+            null,
+            3.14,
+            <String, Object?>{'k': 'v'}
+          ],
         },
         tsSourcePath: 's',
         exportName: 'S',
@@ -200,7 +226,9 @@ void main() {
 
     test('maps FieldKind values to FieldType enum correctly', () {
       final out = emit(_ir([
-        _fs('x', categories: ['x'], fields: [
+        _fs('x', categories: [
+          'x'
+        ], fields: [
           _f('a', kind: FieldKind.dropdown),
           _f('b', kind: FieldKind.multiSelect),
           _f('c', kind: FieldKind.text),
@@ -213,7 +241,9 @@ void main() {
 
     test('forwards optional props: options, hint, required, defaultValue', () {
       final out = emit(_ir([
-        _fs('x', categories: ['x'], fields: [
+        _fs('x', categories: [
+          'x'
+        ], fields: [
           _f(
             'size',
             kind: FieldKind.dropdown,
@@ -234,7 +264,9 @@ void main() {
 
     test('omits options when absent; does not emit required:false', () {
       final out = emit(_ir([
-        _fs('x', categories: ['x'], fields: [
+        _fs('x', categories: [
+          'x'
+        ], fields: [
           _f('notes', kind: FieldKind.text),
         ]),
       ]));
@@ -244,10 +276,15 @@ void main() {
       expect(out, isNot(contains('hint:')));
     });
 
-    test('routing: subcategory routes take precedence over category switch', () {
+    test('routing: subcategory routes take precedence over category switch',
+        () {
       final out = emit(_ir([
-        _fs('watch', categories: ['watch'],
-            subcategoryRoutes: ['watch', 'smartwatch'], fields: [
+        _fs('watch', categories: [
+          'watch'
+        ], subcategoryRoutes: [
+          'watch',
+          'smartwatch'
+        ], fields: [
           _f('type', kind: FieldKind.dropdown),
         ]),
       ]));
@@ -301,7 +338,9 @@ void main() {
 
     test('escapes single-quotes and backslashes in option values', () {
       final out = emit(_ir([
-        _fs('x', categories: ['x'], fields: [
+        _fs('x', categories: [
+          'x'
+        ], fields: [
           _f('h', kind: FieldKind.dropdown, options: ["it's", r'a\b']),
         ]),
       ]));
@@ -311,7 +350,9 @@ void main() {
 
     test('double quotes pass through unescaped in single-quoted strings', () {
       final out = emit(_ir([
-        _fs('x', categories: ['x'], fields: [
+        _fs('x', categories: [
+          'x'
+        ], fields: [
           _f('h', kind: FieldKind.dropdown, options: ['Flat (0-1")']),
         ]),
       ]));

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -116,7 +116,7 @@ void main() {
       expect(
         dart,
         contains(
-          "switch (subcategory.toLowerCase()) {\n"
+          'switch (subcategory.toLowerCase()) {\n'
           "      case 'bug':\n"
           "      case 'feature':\n"
           '        return ticketFields;\n'
@@ -161,7 +161,8 @@ void main() {
         exportName: 'CONFIG',
       );
 
-      expect(dart, contains('const Object? schema = '));
+      // Non-null value emits `Object` (non-nullable); null-at-root would be `Object?`.
+      expect(dart, contains('const Object schema = '));
       expect(dart, contains("'version': '1.0.0'"));
       expect(dart, contains("'baseUrl': 'https://api.example.com'"));
       expect(dart, contains("'timeoutMs': 5000"));


### PR DESCRIPTION
Pure cleanup: `dart analyze` over lib + test + all 4 examples went from 9 issues → 0. Tests 75 → 77 (+2 for Object/Object? emission).

## Changes

- **`map` template type**: emits `const Object schema` (non-nullable) when value is non-null, `const Object? schema = null` only for literal-null exports. Silences `unnecessary_nullable_for_final_variable_declarations` downstream.
- Removed unused `field_definition.dart` imports from three example `main.dart` files.
- Converted double-quoted strings to single quotes in tests (`prefer_single_quotes`).

## Verification

```
$ dart analyze → No issues found!
$ dart test    → 77/77 passing
```

All four examples rebuilt and runtime-verified:
- `example/` (field_definitions)
- `example/map_config/` (map template)
- `example/composed/` (multi-file TS composition)
- `example/multi/` (2 schemas, 2 outputs)

## Version

0.1.3 → 0.1.4. CHANGELOG updated.