### PR TITLE
[archive] feat(0.1.2): multi-schema config, Zod-style validation, fix const lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@ pubspec.lock
 doc/api/
 
 # Example-generated output — regenerated on every `dart run build_runner build`
-example/**/ts_schema.g.dart
+example/**/*.g.dart
 example/**/pubspec.lock
 example/**/.dart_tool/
+
+# The Flutter demo commits its generated file on purpose: viewers browsing
+# the example on GitHub / pub.dev should see what the output looks like,
+# and the hosted demo reads it as a runtime asset. CI regenerates before
+# deploying, so the hosted copy is always current.
+!example/flutter_forms/lib/ts_schema.g.dart
+!example/flutter_forms/assets/ts_schema.g.dart
+
+# Local test artifacts from playwright / screenshot runs.
+.playwright-mcp/
+demo-*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.1.2 — 2026-04-24
+
+### Added
+
+- **Multi-schema config** ([#5]). `build.yaml` now accepts a `schemas` list
+  so one builder invocation can produce multiple outputs from multiple TS
+  entries. Each entry has its own `source`, `export`, `template`,
+  `field_class_import`, and `output`. The old single-schema shape
+  (top-level `source`/`export`/etc.) is still accepted and defaults
+  output to `lib/ts_schema.g.dart` for backward compat.
+- **Configurable output path** ([#5]). `output:` option per schema.
+  Must start with `lib/` (build_runner constraint) and end with `.dart`.
+  Duplicate outputs across schemas are rejected at config-parse time.
+- **Zod-style boundary validation** ([#3]). For `field_definitions` schemas,
+  the Deno side now walks the export before `JSON.stringify` and emits
+  JSON-pointer errors (`SCHEMA.ticket.fields[2].type: expected 'string' |
+  'array' | 'text', got 'txt'`). Skipped for `map` template since that
+  accepts any JSON-serializable value. Exit code 6 distinguishes
+  validation failures from other Deno errors. No network deps — the
+  validator is ~80 lines of hand-rolled TS.
+- New `example/multi/` runnable example demonstrating the multi-schema
+  config with one `field_definitions` + one `map` entry side by side.
+
+### Changed
+
+- `TsSchemaConfig.schemas: List<SchemaEntry>` replaces the flat
+  `source`/`export`/`template`/... fields. External callers constructing
+  the config programmatically (rare) will need to update; the build.yaml
+  options surface stays backward-compatible.
+- `DenoRunner.evaluate` takes an optional `template` parameter (default
+  `'map'`) forwarded to `tool/ts_export.ts` to drive validation.
+
+### Tests
+
+- 55 → 67. +7 config cases for multi-schema + backward compat, +5
+  validator pipeline cases (field-type typo, missing required keys,
+  non-string in categories, happy path, map-template skip).
+
+[#3]: https://github.com/Enraio/ts_schema_codegen/issues/3
+[#5]: https://github.com/Enraio/ts_schema_codegen/issues/5
+
 ## 0.1.1 — 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.1.1 — 2026-04-24
+
+### Added
+
+- **Typed authoring API** ([#2]). Ship `types.ts` at the repo root with
+  `defineSchema`, `FieldSet`, `FieldDef`, `FieldType`. Consumers import
+  via pinned Deno URL (or vendor the ~40 lines) and wrap their schema in
+  `defineSchema(...)` for IDE completion + edit-time typo detection.
+- **Generated registry** ([#4], additive). The `field_definitions`
+  template now emits a `GeneratedFieldSet` class and a
+  `const kFieldSets = <String, GeneratedFieldSet>{...}` map alongside
+  the existing per-fieldset lists and routing switch. Consumers can
+  iterate `kFieldSets`, inspect metadata, and build custom routing
+  without regenerating. Default routing path unchanged — this is purely
+  additive.
+- **Custom JSON replacer** ([#6]) in `tool/ts_export.ts`. `Date`,
+  `BigInt`, `Map`, and `Set` now cross the Deno → Dart boundary as
+  tagged objects (`{__type: 'Date', iso: '...'}` etc.) instead of
+  silently mangling. Plain templates pass them through; future
+  templates can recognize `__type` markers to materialize as typed
+  Dart values.
+
+### Fixed
+
+- `builder_impl.dart` now parses `.dart_tool/package_config.json` with
+  `jsonDecode` instead of a regex. The regex was brittle to any future
+  field reordering; the typed lookup surfaces clearer errors
+  (distinguishes a corrupt config from a missing dev-dependency).
+
+### Tests
+
+- 45 → 55. New cases: registry emission (5), JSON replacer roundtrips
+  (5). See `test/` for the full list.
+
+[#2]: https://github.com/Enraio/ts_schema_codegen/issues/2
+[#4]: https://github.com/Enraio/ts_schema_codegen/issues/4
+[#6]: https://github.com/Enraio/ts_schema_codegen/issues/6
+
 ## 0.1.0 — 2026-04-23
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,44 @@ targets:
           # deno: deno                           # override if not on PATH
 ```
 
-### 4. Provide a `FieldDefinition` class
+### 4. Author your schema with `defineSchema` (recommended)
+
+Import the typed helpers from this package and wrap your schema literal.
+You'll get edit-time completion, typo detection, and refactor safety —
+without waiting for `build_runner` to fail.
+
+```ts
+// schema.ts
+import {
+  defineSchema,
+  type FieldSet,
+} from 'https://raw.githubusercontent.com/Enraio/ts_schema_codegen/v0.1.1/types.ts';
+
+export const SCHEMA = defineSchema({
+  signup: {
+    label: 'Signup',
+    categories: ['signup'],
+    fields: [
+      { id: 'email', type: 'text', label: 'Email', required: true },
+      { id: 'role', type: 'string', label: 'Role',
+        options: ['Engineer', 'Designer', 'Other'] },
+    ],
+  },
+});
+```
+
+Tips:
+
+- **Pin to a tag** (`v0.1.1`), not `main` — so future type tightening
+  doesn't silently break your schema.
+- **Prefer this over raw object literals.** Typing `subcategoryRoute`
+  instead of `subcategoryRoutes` without `defineSchema` silently drops
+  the routes; with `defineSchema` it's a TS error at edit time.
+- **Alternative: vendor the types.** If you'd rather not pull from a
+  remote URL, copy the contents of
+  [`types.ts`](types.ts) into your own repo. It's ~40 lines and stable.
+
+### 5. Provide a `FieldDefinition` class
 
 The `field_definitions` template emits references to `FieldDefinition` and
 `FieldType`. Define them wherever you like and point `field_class_import` at
@@ -205,7 +242,7 @@ class FieldDefinition {
 
 Using the `map` template? Skip this step.
 
-### 5. Generate
+### 6. Generate
 
 ```bash
 dart run build_runner build
@@ -335,6 +372,32 @@ Recognized `FieldDef` properties: `id`, `type` (`string` → `FieldType.dropdown
 tolerated and ignored — carry whatever metadata you want, the emitter only
 reads what it knows.
 
+**Bonus: the generated registry.** The `field_definitions` template also
+emits a `const kFieldSets = <String, GeneratedFieldSet>{...}` map alongside
+the routing function. `GeneratedFieldSet` (also emitted) carries `label`,
+`categories`, `subcategoryRoutes`, and `fields` — so at runtime you can
+iterate every fieldset, introspect metadata, or build your own routing
+without regenerating Dart:
+
+```dart
+import 'ts_schema.g.dart';
+
+// List every fieldset key:
+for (final key in kFieldSets.keys) { print(key); }
+
+// Custom routing (e.g. priority-ordered, regex, memoized):
+List<FieldDefinition> priorityFields(String cat) =>
+    kFieldSets.values
+        .firstWhere(
+          (fs) => fs.categories.contains(cat),
+          orElse: () => kFieldSets['common']!,
+        )
+        .fields;
+```
+
+You can keep using `getFieldsForCategoryGenerated` for the default path
+and reach for `kFieldSets` when you need more.
+
 ## Examples
 
 Three runnable examples under `example/` — open a folder, `dart pub get`,
@@ -370,19 +433,20 @@ The build fails loudly when:
 dart test
 ```
 
-45 tests covering:
+55 tests covering:
 
 - `TsSchemaConfig` validation (8) — required/default options, template
   cross-validation, error messages.
-- Emitter output for both templates (24) — primitives, nested maps/lists,
+- Emitter output for both templates (29) — primitives, nested maps/lists,
   mixed-type lists, string escaping, Unicode, deep nesting, FieldType
   mapping, optional-prop forwarding, missing-prop rejection, extra-key
   tolerance, routing (subcategory precedence, category fallback,
-  no-common-fieldset, insertion order).
-- Deno runner integration (5) — real subprocess, happy path + four failure
-  modes (missing file, missing export, non-JSON-serializable export,
-  composed multi-file imports); skipped automatically if Deno isn't on
-  `PATH`.
+  no-common-fieldset, insertion order), **registry emission**
+  (`GeneratedFieldSet` class + `kFieldSets` map with metadata + ordering).
+- Deno runner integration (10) — real subprocess, happy path + four
+  failure modes, **custom JSON replacer** roundtrips for Date / BigInt /
+  Map / Set (both standalone and nested); skipped automatically if Deno
+  isn't on `PATH`.
 - Full pipeline (4) — TS file on disk → DenoRunner → emitter → Dart
   output, for realistic multi-fieldset schemas, the map template, ordering
   preservation, and composition via imports + `Object.fromEntries`.

--- a/example/composed/schema/index.ts
+++ b/example/composed/schema/index.ts
@@ -1,6 +1,6 @@
 import { user } from './user.ts';
 import { project } from './project.ts';
-import type { FieldSet } from './types.ts';
+import { defineSchema, type FieldSet } from './types.ts';
 
 // The schema is assembled from pieces via `Object.fromEntries` — the exact
 // kind of runtime composition that tree-sitter-style parsers can't handle.
@@ -11,4 +11,4 @@ const ORDERED: Array<[string, FieldSet]> = [
   ['project', project],
 ];
 
-export const SCHEMA: Record<string, FieldSet> = Object.fromEntries(ORDERED);
+export const SCHEMA = defineSchema(Object.fromEntries(ORDERED));

--- a/example/composed/schema/types.ts
+++ b/example/composed/schema/types.ts
@@ -1,18 +1,6 @@
-// Shared type declarations for the composed schema.
+// Re-export the shared types from the package's `types.ts` so fieldset
+// files can import from a short local path. In your own project you'd
+// typically import directly from the pinned URL; this indirection is just
+// ergonomics for the example.
 
-export interface FieldDef {
-  id: string;
-  type: 'string' | 'array' | 'text';
-  label: string;
-  options?: string[];
-  required?: boolean;
-  hint?: string;
-  defaultValue?: string;
-}
-
-export interface FieldSet {
-  label: string;
-  categories: string[];
-  subcategoryRoutes?: string[];
-  fields: FieldDef[];
-}
+export { defineSchema, type FieldDef, type FieldSet, type FieldType } from '../../../types.ts';

--- a/example/multi/README.md
+++ b/example/multi/README.md
@@ -1,0 +1,68 @@
+# example/multi — multiple schemas in one build
+
+Demonstrates the multi-schema config ([#5]): one `build.yaml`, two outputs.
+
+## Layout
+
+```
+example/multi/
+  pubspec.yaml
+  build.yaml                    # declares both schema entries
+  schema/
+    forms.ts                    # field_definitions shape
+    config.ts                   # raw data (map template)
+  lib/
+    field_definition.dart       # consumer-owned FieldDefinition class
+    main.dart                   # reads both generated files
+    forms.g.dart                # GENERATED
+    config.g.dart               # GENERATED
+```
+
+The `build.yaml` options:
+
+```yaml
+schemas:
+  - source: schema/forms.ts
+    export: FORMS
+    template: field_definitions
+    field_class_import: package:<pkg>/field_definition.dart
+    output: lib/forms.g.dart
+  - source: schema/config.ts
+    export: CONFIG
+    template: map
+    output: lib/config.g.dart
+```
+
+## Run
+
+```bash
+cd example/multi
+dart pub get
+dart run build_runner build
+dart run lib/main.dart
+```
+
+Expected output:
+
+```
+Forms: signup
+  - email (text) *
+  - role (dropdown)
+
+Config v1.0.0
+API: https://api.example.com
+  dark_mode: on
+  beta_search: off
+```
+
+## Notes
+
+- **Output paths must start with `lib/` and end with `.dart`** — that's a
+  `build_runner` constraint, not a package one. Builder config validates
+  both up front.
+- **Outputs must be unique.** Collisions surface as an `ArgumentError` at
+  config-parse time ("duplicate output path"), not as a silent last-write-wins.
+- **Different templates per entry are fine.** You can mix `map` and
+  `field_definitions` freely.
+
+[#5]: https://github.com/Enraio/ts_schema_codegen/issues/5

--- a/example/multi/build.yaml
+++ b/example/multi/build.yaml
@@ -1,0 +1,22 @@
+# Multi-schema config (#5) — one builder invocation produces two outputs:
+# `lib/forms.g.dart` from schema/forms.ts and `lib/config.g.dart` from
+# schema/config.ts. Each entry gets its own template + output path; the
+# `field_definitions` entry gets validated via the Zod-style Deno-side
+# validator before Dart emission.
+
+targets:
+  $default:
+    builders:
+      ts_schema_codegen|ts_schema:
+        enabled: true
+        options:
+          schemas:
+            - source: schema/forms.ts
+              export: FORMS
+              template: field_definitions
+              field_class_import: package:ts_schema_codegen_multi_example/field_definition.dart
+              output: lib/forms.g.dart
+            - source: schema/config.ts
+              export: CONFIG
+              template: map
+              output: lib/config.g.dart

--- a/example/multi/lib/field_definition.dart
+++ b/example/multi/lib/field_definition.dart
@@ -1,0 +1,21 @@
+enum FieldType { dropdown, multiSelect, text, number, slider, toggle }
+
+class FieldDefinition {
+  final String id;
+  final String label;
+  final FieldType type;
+  final List<String>? options;
+  final String? hint;
+  final bool required;
+  final Object? defaultValue;
+
+  const FieldDefinition({
+    required this.id,
+    required this.label,
+    required this.type,
+    this.options,
+    this.hint,
+    this.required = false,
+    this.defaultValue,
+  });
+}

--- a/example/multi/lib/main.dart
+++ b/example/multi/lib/main.dart
@@ -1,0 +1,24 @@
+// Reads both generated files — the typed forms (field_definitions) and
+// the raw config (map) — from a single build_runner invocation.
+// Run after `dart run build_runner build`:
+//   dart run lib/main.dart
+
+import 'config.g.dart' as cfg;
+import 'field_definition.dart';
+import 'forms.g.dart' as forms;
+
+void main() {
+  print('Forms: ${forms.kFieldSets.keys.join(", ")}');
+  for (final f in forms.signupFields) {
+    print('  - ${f.id} (${f.type.name})${f.required ? " *" : ""}');
+  }
+  print('');
+
+  final c = cfg.schema as Map<String, Object?>;
+  print('Config v${c['version']}');
+  print('API: ${(c['api'] as Map)['baseUrl']}');
+  final flags = c['flags'] as Map<String, Object?>;
+  flags.forEach((name, enabled) {
+    print('  $name: ${enabled == true ? "on" : "off"}');
+  });
+}

--- a/example/multi/pubspec.yaml
+++ b/example/multi/pubspec.yaml
@@ -1,0 +1,10 @@
+name: ts_schema_codegen_multi_example
+description: Two schemas (forms + config) generated in one build_runner pass.
+publish_to: none
+environment:
+  sdk: ^3.4.0
+
+dev_dependencies:
+  build_runner: ^2.4.15
+  ts_schema_codegen:
+    path: ../..

--- a/example/multi/schema/config.ts
+++ b/example/multi/schema/config.ts
@@ -1,0 +1,5 @@
+export const CONFIG = {
+  version: '1.0.0',
+  api: { baseUrl: 'https://api.example.com', timeoutMs: 30000 },
+  flags: { dark_mode: true, beta_search: false },
+};

--- a/example/multi/schema/forms.ts
+++ b/example/multi/schema/forms.ts
@@ -1,0 +1,17 @@
+import { defineSchema } from '../../../types.ts';
+
+export const FORMS = defineSchema({
+  signup: {
+    label: 'SIGNUP',
+    categories: ['signup'],
+    fields: [
+      { id: 'email', type: 'text', label: 'Email', required: true },
+      {
+        id: 'role',
+        type: 'string',
+        label: 'Role',
+        options: ['Admin', 'Member', 'Guest'],
+      },
+    ],
+  },
+});

--- a/example/schema.ts
+++ b/example/schema.ts
@@ -4,8 +4,15 @@
 // The `field_definitions` template will emit one `const <key>Fields` list
 // per section + a `getFieldsForCategoryGenerated(category, {subcategory})`
 // function that routes a form kind to the right fieldset.
+//
+// `defineSchema` is an identity helper — it preserves the concrete shape of
+// the literal while enforcing `Record<string, FieldSet>` at author time, so
+// IDEs autocomplete keys and TypeScript flags typos like
+// `subcategoryRoute`.
 
-export const FORM_SCHEMA = {
+import { defineSchema } from '../types.ts';
+
+export const FORM_SCHEMA = defineSchema({
   // Fields added to every form, regardless of kind.
   common: {
     label: 'COMMON',
@@ -77,4 +84,4 @@ export const FORM_SCHEMA = {
       },
     ],
   },
-} as const;
+});

--- a/lib/src/builder_impl.dart
+++ b/lib/src/builder_impl.dart
@@ -12,21 +12,22 @@ import 'emitter.dart';
 /// Builder triggered once per consuming package (`$package$`).
 ///
 /// Pipeline:
-///   1. Read options from build.yaml (via constructor).
-///   2. Shell out to Deno with the bundled `tool/ts_export.ts` script,
-///      passing the user's TS entry path + export name.
+///   1. Read options from build.yaml (parsed into [TsSchemaConfig]).
+///   2. For each configured schema: shell out to Deno with the bundled
+///      `tool/ts_export.ts` script, passing the TS entry path, the export
+///      name, and the template (so the Deno side can validate the shape).
 ///   3. Parse the resulting JSON, run it through the selected emitter.
-///   4. Write the Dart source to `lib/ts_schema.g.dart` in the consumer.
-///   5. Format the output via `dart format` so the result plays nicely
-///      with CI diffs and IDEs.
+///   4. Write the Dart source to the configured output path.
+///   5. `dart format --page-width 120` every output so downstream diffs
+///      stay clean across developer runs.
 class TsSchemaBuilder implements Builder {
   TsSchemaBuilder(this.config);
 
   final TsSchemaConfig config;
 
   @override
-  Map<String, List<String>> get buildExtensions => const {
-        r'$package$': ['lib/ts_schema.g.dart'],
+  Map<String, List<String>> get buildExtensions => {
+        r'$package$': config.schemas.map((s) => s.output).toList(),
       };
 
   @override
@@ -40,43 +41,59 @@ class TsSchemaBuilder implements Builder {
       workingDirectory: pkgDir,
     );
 
+    for (final entry in config.schemas) {
+      await _buildOne(
+        buildStep: buildStep,
+        entry: entry,
+        runner: runner,
+        pkgDir: pkgDir,
+      );
+    }
+  }
+
+  Future<void> _buildOne({
+    required BuildStep buildStep,
+    required SchemaEntry entry,
+    required DenoRunner runner,
+    required String pkgDir,
+  }) async {
     final schema = await runner.evaluate(
-      tsPath: config.source,
-      exportName: config.export,
+      tsPath: entry.source,
+      exportName: entry.export,
+      template: entry.template,
     );
 
-    final source = _emit(schema);
+    final source = _emit(schema, entry);
 
-    final output = AssetId(
-      buildStep.inputId.package,
-      'lib/ts_schema.g.dart',
-    );
+    final output = AssetId(buildStep.inputId.package, entry.output);
     await buildStep.writeAsString(output, source);
 
-    // Format after writing so downstream diffs stay clean.
-    await _dartFormat(p.join(pkgDir, 'lib/ts_schema.g.dart'));
+    // Format after writing. The `dart format` subprocess takes the absolute
+    // on-disk path — resolve it relative to the package root.
+    await _dartFormat(p.join(pkgDir, entry.output));
 
     log.info(
-      'ts_schema_codegen: wrote ${source.length} bytes from ${config.source} '
-      '(export=${config.export}, template=${config.template}).',
+      'ts_schema_codegen: wrote ${source.length} bytes to ${entry.output} '
+      'from ${entry.source} (export=${entry.export}, '
+      'template=${entry.template}).',
     );
   }
 
-  String _emit(Object? schema) {
-    switch (config.template) {
+  String _emit(Object? schema, SchemaEntry entry) {
+    switch (entry.template) {
       case 'field_definitions':
         return emitFieldDefinitions(
           schema: schema,
-          fieldClassImport: config.fieldClassImport!,
-          tsSourcePath: config.source,
-          exportName: config.export,
+          fieldClassImport: entry.fieldClassImport!,
+          tsSourcePath: entry.source,
+          exportName: entry.export,
         );
       case 'map':
       default:
         return emitMapTemplate(
           value: schema,
-          tsSourcePath: config.source,
-          exportName: config.export,
+          tsSourcePath: entry.source,
+          exportName: entry.export,
         );
     }
   }
@@ -84,19 +101,6 @@ class TsSchemaBuilder implements Builder {
   /// Locate `tool/ts_export.ts` bundled with this package, regardless of
   /// whether the package is resolved via `path:`, `git:`, or pub.
   String _locateExportScript() {
-    // Package-relative asset resolution: the Dart file we're executing from
-    // is under .dart_tool/build/... at build time, so we can't use __file__.
-    // Instead, resolve via Isolate.resolvePackageUri on our own package URI.
-    // For MVP, rely on PACKAGE_CONFIG to find the package root.
-    //
-    // Simplest correct implementation: walk up from Directory.current looking
-    // for the package's `tool/ts_export.ts`. Since build_runner resolves
-    // package URIs for us, we rely on `package:ts_schema_codegen` pointing
-    // into the right place on disk.
-    // Resolve our package's on-disk root via the consumer's package_config.
-    // `Isolate.resolvePackageUri` is async; build_runner's Builder.build is
-    // already async, but the resolution here is cheap and the sync path
-    // (parsing the checked-in config file) is less fragile across Dart SDKs.
     final config = File(
       p.join(Directory.current.path, '.dart_tool', 'package_config.json'),
     );

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -1,69 +1,204 @@
 /// Options accepted from the consumer's `build.yaml` `options` block.
 ///
-/// Surfaced as a typed object instead of reading the raw map in multiple
-/// places so missing/invalid config fails loudly with a pointer to the
-/// offending key.
+/// Supports two shapes:
+///
+/// **Multi-schema** (preferred for monorepos / multiple schemas):
+///
+/// ```yaml
+/// options:
+///   schemas:
+///     - source: schema/forms.ts
+///       export: FORMS
+///       template: field_definitions
+///       field_class_import: package:app/field_definition.dart
+///       output: lib/forms.g.dart
+///     - source: schema/config.ts
+///       export: CONFIG
+///       template: map
+///       output: lib/config.g.dart
+///   deno: deno  # optional, package-level
+/// ```
+///
+/// **Single-schema** (legacy, still accepted):
+///
+/// ```yaml
+/// options:
+///   source: schema/index.ts
+///   export: FIELD_SCHEMA
+///   template: field_definitions
+///   field_class_import: package:app/field_definition.dart
+///   # output defaults to lib/ts_schema.g.dart for backward compat
+/// ```
+///
+/// The `fromOptions` factory auto-detects the shape by the presence of the
+/// `schemas` key. Validation errors surface with the offending key in the
+/// message so users can map them back to their build.yaml directly.
 class TsSchemaConfig {
-  const TsSchemaConfig({
+  const TsSchemaConfig({required this.schemas, required this.deno});
+
+  /// One or more schemas to process in this build. Guaranteed non-empty.
+  final List<SchemaEntry> schemas;
+
+  /// Command used to invoke Deno. Defaults to `deno`. Override to e.g.
+  /// `/opt/homebrew/bin/deno` if Deno isn't on PATH. Package-level — the
+  /// same Deno is used for every schema.
+  final String deno;
+
+  factory TsSchemaConfig.fromOptions(Map<String, dynamic> opts) {
+    final deno = (opts['deno'] as String?) ?? 'deno';
+    final rawSchemas = opts['schemas'];
+
+    if (rawSchemas != null) {
+      if (rawSchemas is! List) {
+        throw ArgumentError(
+          'ts_schema_codegen: "schemas" option must be a list.',
+        );
+      }
+      if (rawSchemas.isEmpty) {
+        throw ArgumentError(
+          'ts_schema_codegen: "schemas" option must contain at least one '
+          'schema entry.',
+        );
+      }
+      final schemas = <SchemaEntry>[];
+      for (var i = 0; i < rawSchemas.length; i++) {
+        final raw = rawSchemas[i];
+        if (raw is! Map) {
+          throw ArgumentError(
+            'ts_schema_codegen: schemas[$i] must be a map.',
+          );
+        }
+        schemas.add(
+          SchemaEntry._fromMap(
+            Map<String, dynamic>.from(raw),
+            contextPath: 'schemas[$i]',
+          ),
+        );
+      }
+      _validateUniqueOutputs(schemas);
+      return TsSchemaConfig(schemas: schemas, deno: deno);
+    }
+
+    // Single-schema (legacy) shape. Output defaults to lib/ts_schema.g.dart
+    // so existing consumers of 0.1.x keep working without touching build.yaml.
+    if (!opts.containsKey('source')) {
+      throw ArgumentError(
+        'ts_schema_codegen: "source" option is required (or use the '
+        '"schemas" list form for multi-schema).',
+      );
+    }
+    final entry = SchemaEntry._fromMap(
+      {
+        'source': opts['source'],
+        'export': opts['export'],
+        'template': opts['template'],
+        'field_class_import': opts['field_class_import'],
+        'output': opts['output'] ?? 'lib/ts_schema.g.dart',
+      },
+      contextPath: '',
+    );
+    return TsSchemaConfig(schemas: [entry], deno: deno);
+  }
+
+  static void _validateUniqueOutputs(List<SchemaEntry> schemas) {
+    final seen = <String>{};
+    for (final s in schemas) {
+      if (!seen.add(s.output)) {
+        throw ArgumentError(
+          'ts_schema_codegen: duplicate output path "${s.output}" — every '
+          'schema entry must write to a distinct file.',
+        );
+      }
+    }
+  }
+}
+
+/// A single schema the builder should process.
+class SchemaEntry {
+  const SchemaEntry({
     required this.source,
     required this.export,
-    required this.deno,
     required this.template,
     required this.fieldClassImport,
+    required this.output,
   });
 
   /// Path to the TypeScript entry file, relative to the consuming package root.
-  /// e.g. `../supabase/functions/_shared/schema/index.ts`.
   final String source;
 
   /// Name of the top-level export on the TS module to extract.
   /// Defaults to `schema`.
   final String export;
 
-  /// Command used to invoke Deno. Defaults to `deno`.
-  /// Override to e.g. `/opt/homebrew/bin/deno` if Deno isn't on PATH.
-  final String deno;
-
-  /// Template controlling the Dart output shape. Supported:
-  ///   - `map`                 — emits `const Map<String, dynamic> schema = {...}`
-  ///   - `field_definitions`   — emits `FieldDefinition` const lists per
-  ///                             fieldset + a `switch` routing function
-  ///                             (outfii-shaped; requires [fieldClassImport]).
+  /// Template controlling the Dart output shape: `map` or `field_definitions`.
   final String template;
 
-  /// Package-qualified import path for the class referenced by the
-  /// `field_definitions` template. Ignored for the `map` template.
-  /// e.g. `package:outfii/core/models/field_definition.dart`.
+  /// Package-qualified import path for the `FieldDefinition` class referenced
+  /// by the `field_definitions` template. `null` for `map`.
   final String? fieldClassImport;
 
-  factory TsSchemaConfig.fromOptions(Map<String, dynamic> opts) {
-    final source = opts['source'];
+  /// Output path relative to the consuming package root. Must start with
+  /// `lib/` and end with `.dart` (build_runner constraint — generated
+  /// outputs can only live under `lib/`).
+  final String output;
+
+  factory SchemaEntry._fromMap(
+    Map<String, dynamic> raw, {
+    required String contextPath,
+  }) {
+    final where = contextPath.isEmpty ? '' : ' (at $contextPath)';
+
+    final source = raw['source'];
     if (source is! String || source.isEmpty) {
       throw ArgumentError(
-        'ts_schema_codegen: "source" option is required and must be a string '
-        '(path to the TypeScript entry file).',
+        'ts_schema_codegen: "source"$where is required and must be a '
+        'non-empty string (path to the TypeScript entry file).',
       );
     }
-    final template = (opts['template'] as String?) ?? 'map';
+
+    final template = (raw['template'] as String?) ?? 'map';
     if (template != 'map' && template != 'field_definitions') {
       throw ArgumentError(
-        'ts_schema_codegen: unknown template "$template". '
+        'ts_schema_codegen: unknown template "$template"$where. '
         'Supported: map, field_definitions.',
       );
     }
-    final fieldClassImport = opts['field_class_import'] as String?;
-    if (template == 'field_definitions' && (fieldClassImport == null || fieldClassImport.isEmpty)) {
+
+    final fieldClassImport = raw['field_class_import'] as String?;
+    if (template == 'field_definitions' &&
+        (fieldClassImport == null || fieldClassImport.isEmpty)) {
       throw ArgumentError(
-        'ts_schema_codegen: template=field_definitions requires '
+        'ts_schema_codegen: template=field_definitions$where requires '
         '"field_class_import" (package-qualified import of FieldDefinition).',
       );
     }
-    return TsSchemaConfig(
+
+    final output = raw['output'];
+    if (output is! String || output.isEmpty) {
+      throw ArgumentError(
+        'ts_schema_codegen: "output"$where is required and must be a '
+        'non-empty string (e.g. "lib/schema.g.dart").',
+      );
+    }
+    if (!output.startsWith('lib/')) {
+      throw ArgumentError(
+        'ts_schema_codegen: "output"$where must start with "lib/" — '
+        'build_runner only allows generated files under lib/. Got "$output".',
+      );
+    }
+    if (!output.endsWith('.dart')) {
+      throw ArgumentError(
+        'ts_schema_codegen: "output"$where must end with ".dart". '
+        'Got "$output".',
+      );
+    }
+
+    return SchemaEntry(
       source: source,
-      export: (opts['export'] as String?) ?? 'schema',
-      deno: (opts['deno'] as String?) ?? 'deno',
+      export: (raw['export'] as String?) ?? 'schema',
       template: template,
       fieldClassImport: fieldClassImport,
+      output: output,
     );
   }
 }

--- a/lib/src/deno_runner.dart
+++ b/lib/src/deno_runner.dart
@@ -29,11 +29,18 @@ class DenoRunner {
 
   /// Evaluate [tsPath] (relative to [workingDirectory]) and extract the
   /// named export [exportName]. Returns the parsed JSON.
+  ///
+  /// [template] is forwarded to `tool/ts_export.ts` so the Deno side can
+  /// validate the shape before serialization. Unknown templates fall through
+  /// to no validation — the emitter's own checks still apply.
   Future<Object?> evaluate({
     required String tsPath,
     required String exportName,
+    String template = 'map',
   }) async {
-    final absTs = p.isAbsolute(tsPath) ? tsPath : p.normalize(p.join(workingDirectory, tsPath));
+    final absTs = p.isAbsolute(tsPath)
+        ? tsPath
+        : p.normalize(p.join(workingDirectory, tsPath));
     if (!File(absTs).existsSync()) {
       throw StateError(
         'ts_schema_codegen: source file not found at $absTs '
@@ -52,6 +59,7 @@ class DenoRunner {
         exportScriptPath,
         absTs,
         exportName,
+        template,
       ],
       workingDirectory: workingDirectory,
       stdoutEncoding: utf8,

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -122,6 +122,30 @@ String emitFieldDefinitions({
     ..writeln('// Regenerate: dart run build_runner build')
     ..writeln()
     ..writeln("import '$fieldClassImport';")
+    ..writeln()
+    // Emit a self-contained `GeneratedFieldSet` class so the registry
+    // below doesn't force consumers to own a parallel Dart type.
+    ..writeln(
+        '/// Data carrier for the generated fieldset registry (`kFieldSets`).')
+    ..writeln('///')
+    ..writeln('/// Provided by the generator so consumers can reflect on the')
+    ..writeln(
+        '/// schema at runtime — iterate [kFieldSets], build custom routing,')
+    ..writeln(
+        '/// etc. — without depending on a consumer-authored wrapper class.')
+    ..writeln('class GeneratedFieldSet {')
+    ..writeln('  final String label;')
+    ..writeln('  final List<String> categories;')
+    ..writeln('  final List<String> subcategoryRoutes;')
+    ..writeln('  final List<FieldDefinition> fields;')
+    ..writeln()
+    ..writeln('  const GeneratedFieldSet({')
+    ..writeln('    required this.label,')
+    ..writeln('    required this.categories,')
+    ..writeln('    this.subcategoryRoutes = const [],')
+    ..writeln('    required this.fields,')
+    ..writeln('  });')
+    ..writeln('}')
     ..writeln();
 
   // Emit one `const <key>Fields` list per fieldset. When a `common`
@@ -150,6 +174,34 @@ String emitFieldDefinitions({
     buf.writeln('];');
     buf.writeln();
   }
+
+  // Emit the data-driven registry. Keeps the metadata (label, categories,
+  // subcategoryRoutes) discoverable at runtime — a prerequisite for
+  // custom routing policies that consumers build without forking the
+  // emitter.
+  buf.writeln(
+      '/// Registry of every fieldset emitted from the TS schema, keyed');
+  buf.writeln(
+      '/// by fieldset name. Reflectable — iterate [kFieldSets] to build');
+  buf.writeln(
+      '/// custom routing, UIs, or validation without regenerating Dart.');
+  buf.writeln('const kFieldSets = <String, GeneratedFieldSet>{');
+  for (final entry in fieldsets.entries) {
+    final key = entry.key;
+    final label = entry.value['label'];
+    final categories = entry.value['categories'];
+    final subRoutes = entry.value['subcategoryRoutes'];
+    buf.writeln("  '${_escape(key)}': GeneratedFieldSet(");
+    buf.writeln("    label: '${_escape(label?.toString() ?? '')}',");
+    buf.writeln('    categories: ${_stringList(categories)},');
+    if (subRoutes is List && subRoutes.isNotEmpty) {
+      buf.writeln('    subcategoryRoutes: ${_stringList(subRoutes)},');
+    }
+    buf.writeln('    fields: ${key}Fields,');
+    buf.writeln('  ),');
+  }
+  buf.writeln('};');
+  buf.writeln();
 
   // Emit the routing function.
   buf
@@ -266,3 +318,11 @@ String _fieldType(String t) {
 }
 
 String _escape(String s) => s.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
+
+/// Emit an `Object?` value that is expected to be a List<String> as a
+/// Dart literal like `const ['a', 'b']`. Accepts `null` (emits `const []`).
+String _stringList(Object? value) {
+  if (value is! List || value.isEmpty) return 'const <String>[]';
+  final items = value.map((e) => "'${_escape(e.toString())}'").join(', ');
+  return '[$items]';
+}

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -319,10 +319,12 @@ String _fieldType(String t) {
 
 String _escape(String s) => s.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
 
-/// Emit an `Object?` value that is expected to be a List<String> as a
-/// Dart literal like `const ['a', 'b']`. Accepts `null` (emits `const []`).
+/// Emit an `Object?` value that is expected to be a `List<String>` as a
+/// Dart literal. This is only called from inside `const kFieldSets = {...}`,
+/// which is already a const context — so no leading `const` is needed and
+/// emitting one trips the `unnecessary_const` lint.
 String _stringList(Object? value) {
-  if (value is! List || value.isEmpty) return 'const <String>[]';
+  if (value is! List || value.isEmpty) return '<String>[]';
   final items = value.map((e) => "'${_escape(e.toString())}'").join(', ');
   return '[$items]';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ts_schema_codegen
 description: >-
   Generate Dart code from a TypeScript data schema. Evaluates the TS entry
   file with Deno at build time and emits typed Dart constants via build_runner.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/Enraio/ts_schema_codegen
 issue_tracker: https://github.com/Enraio/ts_schema_codegen/issues
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ts_schema_codegen
 description: >-
   Generate Dart code from a TypeScript data schema. Evaluates the TS entry
   file with Deno at build time and emits typed Dart constants via build_runner.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/Enraio/ts_schema_codegen
 issue_tracker: https://github.com/Enraio/ts_schema_codegen/issues
 topics:

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -67,20 +67,24 @@ void main() {
         'source': 'schema.ts',
         'template': 'map',
       });
-      expect(cfg.template, 'map');
-      expect(cfg.fieldClassImport, isNull);
+      expect(cfg.schemas.single.template, 'map');
+      expect(cfg.schemas.single.fieldClassImport, isNull);
     });
 
     test('defaults: export=schema, deno=deno, template=map', () {
       final cfg = TsSchemaConfig.fromOptions({'source': 'schema.ts'});
-      expect(cfg.source, 'schema.ts');
-      expect(cfg.export, 'schema');
+      expect(cfg.schemas, hasLength(1));
+      final entry = cfg.schemas.single;
+      expect(entry.source, 'schema.ts');
+      expect(entry.export, 'schema');
       expect(cfg.deno, 'deno');
-      expect(cfg.template, 'map');
-      expect(cfg.fieldClassImport, isNull);
+      expect(entry.template, 'map');
+      expect(entry.fieldClassImport, isNull);
+      // Legacy single-schema form defaults output to lib/ts_schema.g.dart.
+      expect(entry.output, 'lib/ts_schema.g.dart');
     });
 
-    test('accepts all options together', () {
+    test('accepts all options together (legacy single-schema form)', () {
       final cfg = TsSchemaConfig.fromOptions({
         'source': 'path/to/schema.ts',
         'export': 'FIELD_SCHEMA',
@@ -88,11 +92,140 @@ void main() {
         'template': 'field_definitions',
         'field_class_import': 'package:myapp/field_definition.dart',
       });
-      expect(cfg.source, 'path/to/schema.ts');
-      expect(cfg.export, 'FIELD_SCHEMA');
+      expect(cfg.schemas, hasLength(1));
+      final entry = cfg.schemas.single;
+      expect(entry.source, 'path/to/schema.ts');
+      expect(entry.export, 'FIELD_SCHEMA');
       expect(cfg.deno, '/usr/local/bin/deno');
-      expect(cfg.template, 'field_definitions');
-      expect(cfg.fieldClassImport, 'package:myapp/field_definition.dart');
+      expect(entry.template, 'field_definitions');
+      expect(entry.fieldClassImport, 'package:myapp/field_definition.dart');
+      expect(entry.output, 'lib/ts_schema.g.dart');
+    });
+
+    // --- Multi-schema form (#5) ---
+
+    test('accepts multi-schema form with distinct outputs', () {
+      final cfg = TsSchemaConfig.fromOptions({
+        'schemas': [
+          {
+            'source': 'schema/forms.ts',
+            'export': 'FORMS',
+            'template': 'field_definitions',
+            'field_class_import': 'package:app/field_definition.dart',
+            'output': 'lib/forms.g.dart',
+          },
+          {
+            'source': 'schema/config.ts',
+            'template': 'map',
+            'output': 'lib/config.g.dart',
+          },
+        ],
+      });
+      expect(cfg.schemas, hasLength(2));
+      expect(cfg.schemas[0].source, 'schema/forms.ts');
+      expect(cfg.schemas[0].export, 'FORMS');
+      expect(cfg.schemas[0].template, 'field_definitions');
+      expect(cfg.schemas[0].output, 'lib/forms.g.dart');
+      expect(cfg.schemas[1].source, 'schema/config.ts');
+      expect(cfg.schemas[1].export, 'schema'); // defaulted
+      expect(cfg.schemas[1].template, 'map');
+      expect(cfg.schemas[1].output, 'lib/config.g.dart');
+    });
+
+    test('rejects empty schemas list', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({'schemas': <Object?>[]}),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('at least one schema entry'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects non-list schemas option', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({'schemas': 'not a list'}),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must be a list'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects duplicate output paths across schemas', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({
+          'schemas': [
+            {'source': 'a.ts', 'output': 'lib/x.g.dart'},
+            {'source': 'b.ts', 'output': 'lib/x.g.dart'},
+          ],
+        }),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('duplicate output path'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects output that doesn\'t start with lib/', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({
+          'schemas': [
+            {'source': 'a.ts', 'output': 'generated/x.g.dart'},
+          ],
+        }),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must start with "lib/"'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects output that doesn\'t end with .dart', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({
+          'schemas': [
+            {'source': 'a.ts', 'output': 'lib/x.txt'},
+          ],
+        }),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must end with ".dart"'),
+          ),
+        ),
+      );
+    });
+
+    test('surfaces index in error path for multi-schema failures', () {
+      expect(
+        () => TsSchemaConfig.fromOptions({
+          'schemas': [
+            {'source': 'a.ts', 'output': 'lib/a.g.dart'},
+            {'source': 'b.ts', 'output': 'lib/b.g.dart', 'template': 'xyz'},
+          ],
+        }),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('schemas[1]'), contains('unknown template')),
+          ),
+        ),
+      );
     });
   });
 }

--- a/test/deno_runner_test.dart
+++ b/test/deno_runner_test.dart
@@ -136,6 +136,105 @@ void main() {
         ),
       );
     }, skip: skip);
+
+    // --- JSON replacer: Date / BigInt / Map / Set wrapped as tagged objects ---
+
+    test('Date values are wrapped as {__type: Date, iso: ...}', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const created = new Date('2026-01-15T12:30:00.000Z');
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(
+        tsPath: 'schema.ts',
+        exportName: 'created',
+      );
+      expect(value, {
+        '__type': 'Date',
+        'iso': '2026-01-15T12:30:00.000Z',
+      });
+    }, skip: skip);
+
+    test('BigInt values are wrapped as {__type: BigInt, value: ...}', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const big = 9007199254740993n;
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(
+        tsPath: 'schema.ts',
+        exportName: 'big',
+      );
+      expect(value, {'__type': 'BigInt', 'value': '9007199254740993'});
+    }, skip: skip);
+
+    test('Map values are wrapped as {__type: Map, entries: [...]}', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const m = new Map<string, number>([['a', 1], ['b', 2]]);
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(tsPath: 'schema.ts', exportName: 'm');
+      expect(value, {
+        '__type': 'Map',
+        'entries': [
+          ['a', 1],
+          ['b', 2],
+        ],
+      });
+    }, skip: skip);
+
+    test('Set values are wrapped as {__type: Set, values: [...]}', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const s = new Set<string>(['x', 'y', 'z']);
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(tsPath: 'schema.ts', exportName: 's');
+      expect(value, {
+        '__type': 'Set',
+        'values': ['x', 'y', 'z'],
+      });
+    }, skip: skip);
+
+    test('wrapped types roundtrip inside nested structures', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const SCHEMA = {
+          created: new Date('2026-01-01T00:00:00.000Z'),
+          tags: new Set(['alpha', 'beta']),
+          counts: new Map([['x', 10]]),
+          nested: { bigNum: 1000000000000000000n },
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(
+        tsPath: 'schema.ts',
+        exportName: 'SCHEMA',
+      ) as Map<String, Object?>;
+      expect((value['created'] as Map)['__type'], 'Date');
+      expect((value['tags'] as Map)['__type'], 'Set');
+      expect((value['counts'] as Map)['__type'], 'Map');
+      expect(
+        ((value['nested'] as Map)['bigNum'] as Map)['__type'],
+        'BigInt',
+      );
+    }, skip: skip);
   });
 }
 

--- a/test/emitter_test.dart
+++ b/test/emitter_test.dart
@@ -658,7 +658,7 @@ void main() {
       // Metadata is carried into the registry entry
       expect(out, contains("label: 'COMMON'"));
       expect(out, contains("label: 'TICKET'"));
-      expect(out, contains('categories: const <String>[]'));
+      expect(out, contains('categories: <String>[]'));
       expect(out, contains("categories: ['ticket']"));
       expect(out, contains("subcategoryRoutes: ['bug']"));
       // And the entry references the per-fieldset list we already emit.

--- a/test/emitter_test.dart
+++ b/test/emitter_test.dart
@@ -603,5 +603,142 @@ void main() {
       );
       expect(out, contains("'Flat (0-1\")'"));
     });
+
+    // --- Registry emission (#4, additive) ---
+
+    test('emits GeneratedFieldSet class for the registry', () {
+      final out = emitFieldDefinitions(
+        schema: {
+          'user': {
+            'label': 'USER',
+            'categories': ['user'],
+            'fields': [
+              {'id': 'name', 'type': 'text', 'label': 'Name'},
+            ],
+          },
+        },
+        fieldClassImport: import,
+        tsSourcePath: 's.ts',
+        exportName: 'S',
+      );
+      expect(out, contains('class GeneratedFieldSet {'));
+      expect(out, contains('final String label;'));
+      expect(out, contains('final List<String> categories;'));
+      expect(out, contains('final List<String> subcategoryRoutes;'));
+      expect(out, contains('final List<FieldDefinition> fields;'));
+    });
+
+    test('emits kFieldSets map with one entry per fieldset', () {
+      final out = emitFieldDefinitions(
+        schema: {
+          'common': {
+            'label': 'COMMON',
+            'categories': <String>[],
+            'fields': [
+              {'id': 'consent', 'type': 'string', 'label': 'Consent'},
+            ],
+          },
+          'ticket': {
+            'label': 'TICKET',
+            'categories': ['ticket'],
+            'subcategoryRoutes': ['bug'],
+            'fields': [
+              {'id': 'severity', 'type': 'string', 'label': 'Severity'},
+            ],
+          },
+        },
+        fieldClassImport: import,
+        tsSourcePath: 's.ts',
+        exportName: 'S',
+      );
+      expect(out, contains("const kFieldSets = <String, GeneratedFieldSet>{"));
+      // Each fieldset key is present
+      expect(out, contains("'common': GeneratedFieldSet("));
+      expect(out, contains("'ticket': GeneratedFieldSet("));
+      // Metadata is carried into the registry entry
+      expect(out, contains("label: 'COMMON'"));
+      expect(out, contains("label: 'TICKET'"));
+      expect(out, contains('categories: const <String>[]'));
+      expect(out, contains("categories: ['ticket']"));
+      expect(out, contains("subcategoryRoutes: ['bug']"));
+      // And the entry references the per-fieldset list we already emit.
+      expect(out, contains('fields: commonFields,'));
+      expect(out, contains('fields: ticketFields,'));
+    });
+
+    test('registry omits subcategoryRoutes line when empty', () {
+      final out = emitFieldDefinitions(
+        schema: {
+          'x': {
+            'label': 'X',
+            'categories': ['x'],
+            'fields': [
+              {'id': 'a', 'type': 'text', 'label': 'A'},
+            ],
+          },
+        },
+        fieldClassImport: import,
+        tsSourcePath: 's.ts',
+        exportName: 'S',
+      );
+      // No explicit `subcategoryRoutes:` entry — the generated class's
+      // default (`const []`) takes over.
+      final entryStart = out.indexOf("'x': GeneratedFieldSet(");
+      final entryEnd = out.indexOf('),', entryStart);
+      final entry = out.substring(entryStart, entryEnd);
+      expect(entry, isNot(contains('subcategoryRoutes:')));
+    });
+
+    test('registry escapes special characters in label / routes / categories',
+        () {
+      final out = emitFieldDefinitions(
+        schema: {
+          'it_s': {
+            'label': "it's",
+            'categories': ["a\\b"],
+            'subcategoryRoutes': ["c'd"],
+            'fields': [
+              {'id': 'x', 'type': 'text', 'label': 'X'},
+            ],
+          },
+        },
+        fieldClassImport: import,
+        tsSourcePath: 's.ts',
+        exportName: 'S',
+      );
+      expect(out, contains(r"label: 'it\'s'"));
+      expect(out, contains(r"categories: ['a\\b']"));
+      expect(out, contains(r"subcategoryRoutes: ['c\'d']"));
+    });
+
+    test('registry preserves TS insertion order', () {
+      final out = emitFieldDefinitions(
+        schema: {
+          'zebra': {
+            'label': 'Z',
+            'categories': ['z'],
+            'fields': [
+              {'id': 'a', 'type': 'text', 'label': 'A'},
+            ],
+          },
+          'apple': {
+            'label': 'A',
+            'categories': ['a'],
+            'fields': [
+              {'id': 'b', 'type': 'text', 'label': 'B'},
+            ],
+          },
+        },
+        fieldClassImport: import,
+        tsSourcePath: 's.ts',
+        exportName: 'S',
+      );
+      final registryStart = out.indexOf('const kFieldSets');
+      final zebraIdx = out.indexOf("'zebra': GeneratedFieldSet", registryStart);
+      final appleIdx = out.indexOf("'apple': GeneratedFieldSet", registryStart);
+      expect(zebraIdx, greaterThan(-1));
+      expect(appleIdx, greaterThan(-1));
+      expect(zebraIdx, lessThan(appleIdx));
+    });
   });
 }

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -104,8 +104,10 @@ void main() {
       expect(dart, contains('type: FieldType.text')); // text
 
       // common is appended to non-common fieldsets.
-      final userSpreadIdx = dart.indexOf('...commonFields', dart.indexOf('userFields'));
-      final ticketSpreadIdx = dart.indexOf('...commonFields', dart.indexOf('ticketFields'));
+      final userSpreadIdx =
+          dart.indexOf('...commonFields', dart.indexOf('userFields'));
+      final ticketSpreadIdx =
+          dart.indexOf('...commonFields', dart.indexOf('ticketFields'));
       expect(userSpreadIdx, greaterThan(-1));
       expect(ticketSpreadIdx, greaterThan(-1));
 
@@ -262,6 +264,161 @@ void main() {
       expect(dart, contains("id: 'name'"));
       expect(dart, contains("id: 'email'"));
       expect(dart, contains('const userFields = <FieldDefinition>['));
+    }, skip: skip);
+
+    // --- Validation errors (#3) surface with JSON-pointer paths ---
+
+    test('validator flags bad field type with a JSON-pointer path', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const SCHEMA = {
+          user: {
+            label: 'USER',
+            categories: ['user'],
+            fields: [
+              { id: 'name', type: 'txt', label: 'Name' }, // typo: 'txt' vs 'text'
+            ],
+          },
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      await expectLater(
+        runner.evaluate(
+          tsPath: 'schema.ts',
+          exportName: 'SCHEMA',
+          template: 'field_definitions',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('deno exited with code 6'),
+              contains('SCHEMA.user.fields[0].type'),
+              contains("'string' | 'array' | 'text'"),
+              contains("'txt'"),
+            ),
+          ),
+        ),
+      );
+    }, skip: skip);
+
+    test('validator flags missing required FieldSet fields', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const SCHEMA = {
+          broken: { label: 'B' }, // missing `categories` and `fields`
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      await expectLater(
+        runner.evaluate(
+          tsPath: 'schema.ts',
+          exportName: 'SCHEMA',
+          template: 'field_definitions',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('SCHEMA.broken.categories'),
+              contains('SCHEMA.broken.fields'),
+            ),
+          ),
+        ),
+      );
+    }, skip: skip);
+
+    test('validator flags non-string categories entry', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const SCHEMA = {
+          user: {
+            label: 'USER',
+            categories: ['user', 42, 'member'], // 42 isn't a string
+            fields: [{ id: 'x', type: 'text', label: 'X' }],
+          },
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      await expectLater(
+        runner.evaluate(
+          tsPath: 'schema.ts',
+          exportName: 'SCHEMA',
+          template: 'field_definitions',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('SCHEMA.user.categories[1]'),
+          ),
+        ),
+      );
+    }, skip: skip);
+
+    test('validator accepts a well-formed schema (happy path)', () async {
+      File(p.join(tmp.path, 'schema.ts')).writeAsStringSync('''
+        export const SCHEMA = {
+          user: {
+            label: 'USER',
+            categories: ['user'],
+            subcategoryRoutes: ['member'],
+            fields: [
+              { id: 'email', type: 'text', label: 'Email', required: true },
+              { id: 'role', type: 'string', label: 'Role',
+                options: ['admin', 'member'], hint: 'pick one' },
+              { id: 'tags', type: 'array', label: 'Tags' },
+            ],
+          },
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(
+        tsPath: 'schema.ts',
+        exportName: 'SCHEMA',
+        template: 'field_definitions',
+      );
+      expect(value, isA<Map>());
+    }, skip: skip);
+
+    test('validator is skipped for map template', () async {
+      // A shape that would fail field_definitions validation must pass
+      // through the map template untouched.
+      File(p.join(tmp.path, 'config.ts')).writeAsStringSync('''
+        export const CONFIG = {
+          version: 42, // not a FieldSet — map template doesn't care
+          flags: { beta: true },
+        };
+      ''');
+      final runner = DenoRunner(
+        denoCommand: 'deno',
+        exportScriptPath: exportScript,
+        workingDirectory: tmp.path,
+      );
+      final value = await runner.evaluate(
+        tsPath: 'config.ts',
+        exportName: 'CONFIG',
+        template: 'map',
+      );
+      expect(value, {
+        'version': 42,
+        'flags': {'beta': true},
+      });
     }, skip: skip);
   });
 }

--- a/tool/ts_export.ts
+++ b/tool/ts_export.ts
@@ -9,6 +9,43 @@
 //
 // Errors go to stderr with a non-zero exit code so the Dart side can surface
 // a useful build-failure message.
+//
+// ---------------------------------------------------------------------------
+// Non-JSON-serializable types
+//
+// `JSON.stringify` silently mangles common TS values — Date becomes an ISO
+// string with no type marker; Map and Set become `{}` (empty object), losing
+// their contents; BigInt throws. We wrap them as tagged objects:
+//
+//   Date   → { __type: 'Date',   iso:     string }
+//   BigInt → { __type: 'BigInt', value:   string }        // stringified for precision
+//   Map    → { __type: 'Map',    entries: [key, value][] }
+//   Set    → { __type: 'Set',    values:  unknown[] }
+//
+// The Dart side sees these as plain Map<String, Object?> and can decide
+// whether to materialize them as typed Dart values (DateTime, BigInt, etc.)
+// — that's template work. For now, data survives the crossing.
+
+function replacer(this: unknown, key: string, value: unknown): unknown {
+  // `Date` has a built-in `toJSON()` that stringify calls BEFORE the
+  // replacer, so by the time we see `value` for a Date it's already a
+  // string. The unmodified value still sits on the holder object at
+  // `this[key]` — reach into it directly.
+  const raw = (this as Record<string, unknown> | null)?.[key];
+  if (raw instanceof Date) {
+    return { __type: 'Date', iso: raw.toISOString() };
+  }
+  if (typeof value === 'bigint') {
+    return { __type: 'BigInt', value: value.toString() };
+  }
+  if (value instanceof Map) {
+    return { __type: 'Map', entries: Array.from(value.entries()) };
+  }
+  if (value instanceof Set) {
+    return { __type: 'Set', values: Array.from(value) };
+  }
+  return value;
+}
 
 if (import.meta.main) {
   const [tsPath, exportName] = Deno.args;
@@ -20,9 +57,7 @@ if (import.meta.main) {
   }
 
   // Dynamic import with file:// URL so absolute paths work cross-platform.
-  const url = tsPath.startsWith('file://')
-    ? tsPath
-    : `file://${tsPath}`;
+  const url = tsPath.startsWith('file://') ? tsPath : `file://${tsPath}`;
 
   let mod: Record<string, unknown>;
   try {
@@ -46,7 +81,7 @@ if (import.meta.main) {
   const value = mod[exportName];
   let serialized: string;
   try {
-    serialized = JSON.stringify(value);
+    serialized = JSON.stringify(value, replacer);
   } catch (err) {
     console.error(
       `ts_export: export "${exportName}" is not JSON-serializable ` +

--- a/tool/ts_export.ts
+++ b/tool/ts_export.ts
@@ -1,15 +1,25 @@
 // Bundled Deno evaluator for ts_schema_codegen.
 //
 // Invoked by the Dart Builder at build time. Given a path to a user's TS
-// entry file and the name of an export, dynamically imports the module and
-// prints `JSON.stringify(mod[exportName])` to stdout.
+// entry file, the name of an export, and a template name, dynamically
+// imports the module, optionally validates the shape (for
+// `field_definitions`), and prints `JSON.stringify(mod[exportName])` to
+// stdout.
 //
 // Usage:
-//   deno run --allow-read ts_export.ts <absolute-path-to-user-ts> <export-name>
+//   deno run --allow-read ts_export.ts <ts-path> <export-name> <template>
 //
-// Errors go to stderr with a non-zero exit code so the Dart side can surface
-// a useful build-failure message.
+// Exit codes:
+//   0 success
+//   2 bad args
+//   3 import failed
+//   4 export not found
+//   5 not JSON-serializable
+//   6 validation failed (field_definitions shape mismatch)
 //
+// Errors go to stderr with JSON-pointer paths where applicable so the Dart
+// side can surface them verbatim.
+
 // ---------------------------------------------------------------------------
 // Non-JSON-serializable types
 //
@@ -21,10 +31,6 @@
 //   BigInt → { __type: 'BigInt', value:   string }        // stringified for precision
 //   Map    → { __type: 'Map',    entries: [key, value][] }
 //   Set    → { __type: 'Set',    values:  unknown[] }
-//
-// The Dart side sees these as plain Map<String, Object?> and can decide
-// whether to materialize them as typed Dart values (DateTime, BigInt, etc.)
-// — that's template work. For now, data survives the crossing.
 
 function replacer(this: unknown, key: string, value: unknown): unknown {
   // `Date` has a built-in `toJSON()` that stringify calls BEFORE the
@@ -47,11 +53,189 @@ function replacer(this: unknown, key: string, value: unknown): unknown {
   return value;
 }
 
+// ---------------------------------------------------------------------------
+// Hand-rolled validator for the `field_definitions` template.
+//
+// Hand-rolled (no Zod) because this package already requires Deno; adding a
+// network-fetched dep is worse than the ~80 lines below. Errors carry a
+// JSON-pointer-ish `path` (e.g. `SCHEMA.ticket.fields[2].type`) so users can
+// map the failure back to their TS source directly.
+
+type Issue = { path: string; expected: string; got: string };
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function whatIs(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}
+
+function validateFieldDefinitionsSchema(
+  root: unknown,
+  rootPath: string,
+): Issue[] {
+  const issues: Issue[] = [];
+
+  if (!isObject(root)) {
+    issues.push({
+      path: rootPath,
+      expected: 'object (Record<fieldsetKey, FieldSet>)',
+      got: whatIs(root),
+    });
+    return issues;
+  }
+
+  for (const [fieldsetKey, fieldsetVal] of Object.entries(root)) {
+    const fsPath = `${rootPath}.${fieldsetKey}`;
+
+    if (!isObject(fieldsetVal)) {
+      issues.push({
+        path: fsPath,
+        expected: 'FieldSet object',
+        got: whatIs(fieldsetVal),
+      });
+      continue;
+    }
+
+    if (typeof fieldsetVal.label !== 'string') {
+      issues.push({
+        path: `${fsPath}.label`,
+        expected: 'string',
+        got: whatIs(fieldsetVal.label),
+      });
+    }
+
+    if (!Array.isArray(fieldsetVal.categories)) {
+      issues.push({
+        path: `${fsPath}.categories`,
+        expected: 'string[]',
+        got: whatIs(fieldsetVal.categories),
+      });
+    } else {
+      fieldsetVal.categories.forEach((c, i) => {
+        if (typeof c !== 'string') {
+          issues.push({
+            path: `${fsPath}.categories[${i}]`,
+            expected: 'string',
+            got: whatIs(c),
+          });
+        }
+      });
+    }
+
+    if (fieldsetVal.subcategoryRoutes !== undefined) {
+      if (!Array.isArray(fieldsetVal.subcategoryRoutes)) {
+        issues.push({
+          path: `${fsPath}.subcategoryRoutes`,
+          expected: 'string[] (or omit)',
+          got: whatIs(fieldsetVal.subcategoryRoutes),
+        });
+      } else {
+        fieldsetVal.subcategoryRoutes.forEach((r, i) => {
+          if (typeof r !== 'string') {
+            issues.push({
+              path: `${fsPath}.subcategoryRoutes[${i}]`,
+              expected: 'string',
+              got: whatIs(r),
+            });
+          }
+        });
+      }
+    }
+
+    if (!Array.isArray(fieldsetVal.fields)) {
+      issues.push({
+        path: `${fsPath}.fields`,
+        expected: 'FieldDef[]',
+        got: whatIs(fieldsetVal.fields),
+      });
+      continue;
+    }
+
+    fieldsetVal.fields.forEach((field, i) => {
+      const fPath = `${fsPath}.fields[${i}]`;
+      if (!isObject(field)) {
+        issues.push({
+          path: fPath,
+          expected: 'FieldDef object',
+          got: whatIs(field),
+        });
+        return;
+      }
+      if (typeof field.id !== 'string') {
+        issues.push({
+          path: `${fPath}.id`,
+          expected: 'string',
+          got: whatIs(field.id),
+        });
+      }
+      if (typeof field.label !== 'string') {
+        issues.push({
+          path: `${fPath}.label`,
+          expected: 'string',
+          got: whatIs(field.label),
+        });
+      }
+      if (
+        field.type !== 'string' &&
+        field.type !== 'array' &&
+        field.type !== 'text'
+      ) {
+        issues.push({
+          path: `${fPath}.type`,
+          expected: "'string' | 'array' | 'text'",
+          got: typeof field.type === 'string'
+            ? `'${field.type}'`
+            : whatIs(field.type),
+        });
+      }
+      if (field.options !== undefined && !Array.isArray(field.options)) {
+        issues.push({
+          path: `${fPath}.options`,
+          expected: 'string[] (or omit)',
+          got: whatIs(field.options),
+        });
+      }
+      if (field.required !== undefined && typeof field.required !== 'boolean') {
+        issues.push({
+          path: `${fPath}.required`,
+          expected: 'boolean (or omit)',
+          got: whatIs(field.required),
+        });
+      }
+      if (field.hint !== undefined && typeof field.hint !== 'string') {
+        issues.push({
+          path: `${fPath}.hint`,
+          expected: 'string (or omit)',
+          got: whatIs(field.hint),
+        });
+      }
+    });
+  }
+
+  return issues;
+}
+
+function formatIssues(issues: Issue[], exportName: string): string {
+  const lines = [`ts_schema_codegen: invalid schema in export "${exportName}"`];
+  for (const issue of issues) {
+    lines.push(`  at ${issue.path}`);
+    lines.push(`    expected: ${issue.expected}`);
+    lines.push(`    got:      ${issue.got}`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+
 if (import.meta.main) {
-  const [tsPath, exportName] = Deno.args;
+  const [tsPath, exportName, template = 'map'] = Deno.args;
   if (!tsPath || !exportName) {
     console.error(
-      'ts_export: expected two arguments — <ts-path> <export-name>',
+      'ts_export: expected three arguments — <ts-path> <export-name> <template>',
     );
     Deno.exit(2);
   }
@@ -79,6 +263,15 @@ if (import.meta.main) {
   }
 
   const value = mod[exportName];
+
+  if (template === 'field_definitions') {
+    const issues = validateFieldDefinitionsSchema(value, exportName);
+    if (issues.length > 0) {
+      console.error(formatIssues(issues, exportName));
+      Deno.exit(6);
+    }
+  }
+
   let serialized: string;
   try {
     serialized = JSON.stringify(value, replacer);

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,90 @@
+// Typed authoring helpers for ts_schema_codegen.
+//
+// Consume from your TS schema via Deno URL import:
+//
+//   import {
+//     defineSchema,
+//     type FieldDef,
+//     type FieldSet,
+//     type FieldType,
+//   } from 'https://raw.githubusercontent.com/Enraio/ts_schema_codegen/v0.1.1/types.ts';
+//
+// Pin to a tag (`v0.1.1`) rather than `main` so schema drift can't silently
+// change types under your feet. Alternatively, vendor this file into your
+// own repo — it's ~40 lines and stable.
+//
+// These types describe exactly what the `field_definitions` template in
+// the Dart side emits; getting them wrong in TS will surface as either a
+// TypeScript error at edit time (good) or a schema validation error at
+// `dart run build_runner build` time (ok-ish — but you wanted the former,
+// which is why this file exists).
+
+/** Kind of input the Dart UI renders for this field. */
+export type FieldType = 'string' | 'array' | 'text';
+
+/** Single extractable attribute inside a fieldset. */
+export interface FieldDef {
+  /** Stable identifier (e.g. `'email'`, `'fabric'`). */
+  id: string;
+  /** `'string'` → dropdown, `'array'` → multi-select, `'text'` → freeform. */
+  type: FieldType;
+  /** UI label shown to the user. */
+  label: string;
+  /** Allowed values for dropdown / multi-select. */
+  options?: readonly string[];
+  /** Placeholder / help text in the UI. */
+  hint?: string;
+  /** Whether the field must be filled. */
+  required?: boolean;
+  /** Pre-populated default. */
+  defaultValue?: string;
+  /**
+   * Any additional metadata your tooling needs (abbreviation, aiRelevant,
+   * compactAs, etc.). Tolerated by the emitter — carry whatever shape you
+   * want and read it from the registry at runtime.
+   */
+  readonly [key: string]: unknown;
+}
+
+/** Group of fields that applies to one or more item categories. */
+export interface FieldSet {
+  /** Display label for this fieldset (e.g. `'FORMS'`). */
+  label: string;
+  /** Top-level categories that route to this fieldset. */
+  categories: readonly string[];
+  /**
+   * Subcategory values that also route here. Checked **before** the
+   * category switch — useful for backward-compat routing of legacy
+   * subcategories.
+   */
+  subcategoryRoutes?: readonly string[];
+  /** Fields emitted as `const <key>Fields = <FieldDefinition>[...]`. */
+  fields: readonly FieldDef[];
+}
+
+/**
+ * Identity helper that pins the shape of your schema at author time.
+ *
+ * Wrap your schema in `defineSchema(...)` to get:
+ *   - IDE completion on every fieldset and field key
+ *   - Compile-time errors for misspelled keys (`subcategoryRoute` vs
+ *     `subcategoryRoutes`)
+ *   - Refactor safety when the types here evolve in a future release
+ *
+ * ```ts
+ * export const SCHEMA = defineSchema({
+ *   signup: {
+ *     label: 'Signup',
+ *     categories: ['signup'],
+ *     fields: [
+ *       { id: 'email', type: 'text', label: 'Email', required: true },
+ *     ],
+ *   },
+ * });
+ * ```
+ *
+ * The generic parameter `S` is inferred — your call sites see the concrete
+ * shape of your schema, not the generic `Record<string, FieldSet>`.
+ */
+export const defineSchema = <S extends Record<string, FieldSet>>(schema: S): S =>
+  schema;


### PR DESCRIPTION
Archived branch — local work pushed before deleting the local copy of this repo.

This branch carries commits whose original remote counterpart was deleted ([gone] tracking). Pushed here so the work is preserved on GitHub before the local repo is removed. Review and merge or close as appropriate.

Branch: `feat/0.1.2`
Latest commit: feat(0.1.2): multi-schema config, Zod-style validation, fix const lint